### PR TITLE
Displaying `warn` level messages for file collisions

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.groovy
@@ -245,9 +245,13 @@ public class ShadowCopyAction implements CopyAction {
                     }
                 } else {
                     def archiveFileInVisitedFiles = visitedFiles.get(archiveFilePath.toString())
-                    if (archiveFileInVisitedFiles && (archiveFileInVisitedFiles.size != fileDetails.size) && !archiveFilePath.toString().startsWith('META-INF/')) {
+                    if (archiveFileInVisitedFiles && (archiveFileInVisitedFiles.size != fileDetails.size)) {
                         log.warn("IGNORING ${archiveFilePath} from ${fileDetails.relativePath}, size is different (${fileDetails.size} vs ${archiveFileInVisitedFiles.size})")
-                        log.warn("  --> origin JAR was ${archiveFileInVisitedFiles.originJar}")
+                        if (archiveFileInVisitedFiles.originJar) {
+                            log.warn("  --> origin JAR was ${archiveFileInVisitedFiles.originJar}")
+                        } else {
+                            log.warn("  --> file originated from project sourcecode")
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
We experienced problems in a recent project where Java property files were being left out due to collisions with other JARs in the project. In the course of debugging the issue, we tried the [OneJar Gradle plugin](https://github.com/rholder/gradle-one-jar) which printed debug messages about these collisions. This PR adds the same functionality to the Shadow plugin.

With warnings about file collisions, it's trivial to add appropriate appending transformers to the Gradle task for the shadow JAR. One interesting thing we noticed with this was frequent collisions on `META-INF/LICENSE`, which has possibly interesting ramifications for some projects, e.g. anything that includes an Affero GPL license.

It was necessary to modify the `visitedFiles` data structure to allow storing the source JAR and file size without ripping through JAR files again. We provided several overloaded methods to allow insertion into `visitedFiles`.
