### PR TITLE
Fix compatibility with Gradle 2.5. Fixes #147

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     compile 'org.ow2.asm:asm-commons:5.0.3'
     compile 'commons-io:commons-io:2.4'
     compile 'org.apache.ant:ant:1.9.4'
+    compile 'org.codehaus.plexus:plexus-utils:2.0.6'
 
     testUtilsCompile localGroovy()
     testUtilsCompile gradleApi()

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocator.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocator.groovy
@@ -19,7 +19,7 @@
 
 package com.github.jengelman.gradle.plugins.shadow.relocation
 
-import org.gradle.mvn3.org.codehaus.plexus.util.SelectorUtils
+import org.codehaus.plexus.util.SelectorUtils
 
 import java.util.regex.Pattern
 

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.groovy
@@ -22,8 +22,8 @@ package com.github.jengelman.gradle.plugins.shadow.transformers
 import com.github.jengelman.gradle.plugins.shadow.relocation.Relocator
 import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
+import org.codehaus.plexus.util.StringUtils
 import org.gradle.api.file.FileTreeElement
-import org.gradle.mvn3.org.codehaus.plexus.util.StringUtils
 
 import java.text.SimpleDateFormat
 

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformer.groovy
@@ -22,8 +22,8 @@ package com.github.jengelman.gradle.plugins.shadow.transformers
 import com.github.jengelman.gradle.plugins.shadow.relocation.Relocator
 import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
+import org.codehaus.plexus.util.IOUtil
 import org.gradle.api.file.FileTreeElement
-import org.gradle.mvn3.org.codehaus.plexus.util.IOUtil
 
 /**
  * A resource processor that appends content for a resource, separated by a newline.

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformer.groovy
@@ -23,12 +23,12 @@ import com.github.jengelman.gradle.plugins.shadow.relocation.Relocator
 import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
 import org.gradle.api.file.FileTreeElement
-import org.gradle.mvn3.org.codehaus.plexus.util.IOUtil
-import org.gradle.mvn3.org.codehaus.plexus.util.ReaderFactory
-import org.gradle.mvn3.org.codehaus.plexus.util.WriterFactory
-import org.gradle.mvn3.org.codehaus.plexus.util.xml.Xpp3Dom
-import org.gradle.mvn3.org.codehaus.plexus.util.xml.Xpp3DomBuilder
-import org.gradle.mvn3.org.codehaus.plexus.util.xml.Xpp3DomWriter
+import org.codehaus.plexus.util.IOUtil
+import org.codehaus.plexus.util.ReaderFactory
+import org.codehaus.plexus.util.WriterFactory
+import org.codehaus.plexus.util.xml.Xpp3Dom
+import org.codehaus.plexus.util.xml.Xpp3DomBuilder
+import org.codehaus.plexus.util.xml.Xpp3DomWriter
 
 /**
  * A resource processor that aggregates plexus <code>components.xml</code> files.

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/GroovyExtensionModuleTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/GroovyExtensionModuleTransformer.groovy
@@ -23,7 +23,7 @@ import com.github.jengelman.gradle.plugins.shadow.relocation.Relocator
 import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
 import org.gradle.api.file.FileTreeElement
-import org.gradle.mvn3.org.codehaus.plexus.util.IOUtil
+import org.codehaus.plexus.util.IOUtil
 
 /**
  * Modified from eu.appsatori.gradle.fatjar.tasks.PrepareFiles.groovy

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/IncludeResourceTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/IncludeResourceTransformer.groovy
@@ -23,7 +23,7 @@ import com.github.jengelman.gradle.plugins.shadow.relocation.Relocator
 import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
 import org.gradle.api.file.FileTreeElement
-import org.gradle.mvn3.org.codehaus.plexus.util.IOUtil
+import org.codehaus.plexus.util.IOUtil
 
 /**
  * A resource processor that allows the addition of an arbitrary file

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestResourceTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestResourceTransformer.groovy
@@ -23,7 +23,7 @@ import com.github.jengelman.gradle.plugins.shadow.relocation.Relocator
 import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
 import org.gradle.api.file.FileTreeElement
-import org.gradle.mvn3.org.codehaus.plexus.util.IOUtil
+import org.codehaus.plexus.util.IOUtil
 
 import java.util.jar.*
 import java.util.jar.Attributes.Name

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformer.groovy
@@ -23,7 +23,7 @@ import com.github.jengelman.gradle.plugins.shadow.relocation.Relocator
 import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
 import org.gradle.api.file.FileTreeElement
-import org.gradle.mvn3.org.codehaus.plexus.util.IOUtil
+import org.codehaus.plexus.util.IOUtil
 
 /**
  * Resources transformer that merges Properties files.

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.groovy
@@ -26,7 +26,7 @@ import org.gradle.api.file.FileTreeElement
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.util.PatternFilterable
 import org.gradle.api.tasks.util.PatternSet
-import org.gradle.mvn3.org.codehaus.plexus.util.IOUtil
+import org.codehaus.plexus.util.IOUtil
 
 /**
  * Modified from org.apache.maven.plugins.shade.resource.ServiceResourceTransformer.java

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformerTest.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformerTest.groovy
@@ -25,7 +25,7 @@ import org.custommonkey.xmlunit.Diff
 import org.custommonkey.xmlunit.XMLAssert
 import org.custommonkey.xmlunit.XMLUnit
 import com.github.jengelman.gradle.plugins.shadow.relocation.Relocator
-import org.gradle.mvn3.org.codehaus.plexus.util.IOUtil
+import org.codehaus.plexus.util.IOUtil
 
 /**
  * Test for {@link ComponentsXmlResourceTransformer}.

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/JarBuilder.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/JarBuilder.groovy
@@ -1,6 +1,6 @@
 package com.github.jengelman.gradle.plugins.shadow.util
 
-import org.gradle.mvn3.org.codehaus.plexus.util.IOUtil
+import org.codehaus.plexus.util.IOUtil
 
 import java.util.jar.JarEntry
 import java.util.jar.JarOutputStream

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/PluginSpecification.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/PluginSpecification.groovy
@@ -2,7 +2,7 @@ package com.github.jengelman.gradle.plugins.shadow.util
 
 import com.github.jengelman.gradle.testkit.GradleRunnerFactory
 import com.github.jengelman.gradle.testkit.file.TestFile
-import org.gradle.mvn3.org.codehaus.plexus.util.IOUtil
+import org.codehaus.plexus.util.IOUtil
 import org.gradle.testkit.functional.ExecutionResult
 import org.gradle.testkit.functional.GradleRunner
 import org.junit.Rule


### PR DESCRIPTION
Wanted to upgrade my project to Gradle 2.5 today but noticed shadow was broken - because I wanted to continue the upgrade today I was looking into a fix for the problem. Basically Gradle 2.5 bundles only Maven 3 so the `plexus-utils` are no longer relocated in a different package.

This changes the imports to the new (original) packages and adds a dependency on the original `plexus-utils` which should (hopefully) maintain compatibility with older Gradle versions as well. While I have tested this successfully on Gradle 2.5, as well as some older Gradle versions like 2.4 and 1.12 I'm not completely sure if this will always work for older Gradle versions.

The fix is probably not perfect, so if you've started already or see a better way feel free to close this, just thought it may help you to fix it a little bit faster. :)

Fixes #147 