### PR TITLE
Perform relocation while merging service files

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.groovy
@@ -67,7 +67,16 @@ class ServiceFileTransformer implements Transformer, PatternFilterable {
 
     @Override
     void transform(String path, InputStream is, List<Relocator> relocators) {
-        serviceEntries[path].append(is)
+        def lines = is.readLines()
+        relocators.each {rel ->
+            path = rel.relocateClass(path)
+            lines.eachWithIndex { String line, int i ->
+                if(rel.canRelocateClass(line)) {
+                    lines[i] = rel.relocateClass(line)
+                }
+            }
+        }
+        lines.each {line -> serviceEntries[path].append(new ByteArrayInputStream(line.getBytes()))}
     }
 
     @Override

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.groovy
@@ -69,7 +69,9 @@ class ServiceFileTransformer implements Transformer, PatternFilterable {
     void transform(String path, InputStream is, List<Relocator> relocators) {
         def lines = is.readLines()
         relocators.each {rel ->
-            path = rel.relocateClass(path)
+            if(rel.canRelocateClass(new File(path).name)) {
+                path = rel.relocateClass(path)
+            }
             lines.eachWithIndex { String line, int i ->
                 if(rel.canRelocateClass(line)) {
                     lines[i] = rel.relocateClass(line)

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/TransformerSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/TransformerSpec.groovy
@@ -149,6 +149,8 @@ class TransformerSpec extends PluginSpecification {
                    |org.apache.hive.jdbc.HiveDriver'''.stripMargin())
                 .insertFile('META-INF/services/org.apache.axis.components.compiler.Compiler',
                 'org.apache.axis.components.compiler.Javac')
+                .insertFile('META-INF/services/org.apache.commons.logging.LogFactory',
+                'org.apache.commons.logging.impl.LogFactoryImpl')
                 .write()
 
         File two = buildJar('two.jar')
@@ -157,6 +159,8 @@ class TransformerSpec extends PluginSpecification {
                    |com.mysql.jdbc.Driver'''.stripMargin())
                 .insertFile('META-INF/services/org.apache.axis.components.compiler.Compiler',
                 'org.apache.axis.components.compiler.Jikes')
+                .insertFile('META-INF/services/org.apache.commons.logging.LogFactory',
+                'org.mortbay.log.Factory')
                 .write()
 
         buildFile << """
@@ -168,6 +172,7 @@ class TransformerSpec extends PluginSpecification {
             |    mergeServiceFiles()
             |    relocate('org.apache', 'myapache') {
             |        exclude 'org.apache.axis.components.compiler.Jikes'
+            |        exclude 'org.apache.commons.logging.LogFactory'
             |    }
             |}
         """.stripMargin()
@@ -193,6 +198,12 @@ class TransformerSpec extends PluginSpecification {
         assert text2.split('(\r\n)|(\r)|(\n)').size() == 2
         assert text2 == '''|myapache.axis.components.compiler.Javac
                            |org.apache.axis.components.compiler.Jikes'''.stripMargin()
+
+        and:
+        String text3 = getJarFileContents(output, 'META-INF/services/org.apache.commons.logging.LogFactory')
+        assert text3.split('(\r\n)|(\r)|(\n)').size() == 2
+        assert text3 == '''|myapache.commons.logging.impl.LogFactoryImpl
+                           |org.mortbay.log.Factory'''.stripMargin()
     }
 
     def 'service resource transformer short syntax alternate path'() {

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/TransformerSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/TransformerSpec.groovy
@@ -141,6 +141,60 @@ class TransformerSpec extends PluginSpecification {
             assert text2 == 'one'
     }
 
+    def 'service resource transformer short syntax relocation'() {
+        given:
+        File one = buildJar('one.jar')
+                .insertFile('META-INF/services/java.sql.Driver',
+                '''|oracle.jdbc.OracleDriver
+                   |org.apache.hive.jdbc.HiveDriver'''.stripMargin())
+                .insertFile('META-INF/services/org.apache.axis.components.compiler.Compiler',
+                'org.apache.axis.components.compiler.Javac')
+                .write()
+
+        File two = buildJar('two.jar')
+                .insertFile('META-INF/services/java.sql.Driver',
+                '''|org.apache.derby.jdbc.AutoloadedDriver
+                   |com.mysql.jdbc.Driver'''.stripMargin())
+                .insertFile('META-INF/services/org.apache.axis.components.compiler.Compiler',
+                'org.apache.axis.components.compiler.Jikes')
+                .write()
+
+        buildFile << """
+            |task shadow(type: ${ShadowJar.name}) {
+            |    destinationDir = new File(buildDir, 'libs')
+            |    baseName = 'shadow'
+            |    from('${escapedPath(one)}')
+            |    from('${escapedPath(two)}')
+            |    mergeServiceFiles()
+            |    relocate('org.apache', 'myapache') {
+            |        exclude 'org.apache.axis.components.compiler.Jikes'
+            |    }
+            |}
+        """.stripMargin()
+
+        when:
+        runner.arguments << 'shadow'
+        ExecutionResult result = runner.run()
+
+        then:
+        success(result)
+        assert output.exists()
+
+        and:
+        String text1 = getJarFileContents(output, 'META-INF/services/java.sql.Driver')
+        assert text1.split('(\r\n)|(\r)|(\n)').size() == 4
+        assert text1 == '''|oracle.jdbc.OracleDriver
+                           |myapache.hive.jdbc.HiveDriver
+                           |myapache.derby.jdbc.AutoloadedDriver
+                           |com.mysql.jdbc.Driver'''.stripMargin()
+
+        and:
+        String text2 = getJarFileContents(output, 'META-INF/services/myapache.axis.components.compiler.Compiler')
+        assert text2.split('(\r\n)|(\r)|(\n)').size() == 2
+        assert text2 == '''|myapache.axis.components.compiler.Javac
+                           |org.apache.axis.components.compiler.Jikes'''.stripMargin()
+    }
+
     def 'service resource transformer short syntax alternate path'() {
         given:
             File one = buildJar('one.jar').insertFile('META-INF/foo/org.apache.maven.Shade',


### PR DESCRIPTION
The relocation rules should be taken into account while merging service files. This involves both the name and the content of the service files.