### PR TITLE
fix for #217: changes for Manifest on gradle side (version 2.14-rc-1) are propagated to shadow plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,8 @@ dependencies {
         exclude module: 'groovy-all'
     }
     testCompile 'xmlunit:xmlunit:1.3'
+    testCompile 'org.apache.commons:commons-lang3:3.4'
+    testCompile 'com.google.guava:guava-testlib:19.0'
 }
 
 test {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-rc-1-bin.zip

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/DefaultInheritManifest.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/DefaultInheritManifest.groovy
@@ -1,5 +1,6 @@
 package com.github.jengelman.gradle.plugins.shadow.tasks
 
+import org.gradle.api.InvalidUserDataException
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.java.archives.Attributes
 import org.gradle.api.java.archives.Manifest
@@ -7,6 +8,8 @@ import org.gradle.api.java.archives.ManifestException
 import org.gradle.api.java.archives.internal.DefaultManifest
 import org.gradle.api.java.archives.internal.DefaultManifestMergeSpec
 import org.gradle.util.ConfigureUtil
+
+import java.nio.charset.Charset
 
 class DefaultInheritManifest implements InheritManifest {
 
@@ -67,8 +70,30 @@ class DefaultInheritManifest implements InheritManifest {
     }
 
     @Override
+    String getContentCharset() {
+        return internalManifest.getContentCharset()
+    }
+
+    @Override
+    void setContentCharset(String contentCharset) {
+        if (contentCharset == null) {
+            throw new InvalidUserDataException("contentCharset must not be null");
+        }
+        if (!Charset.isSupported(contentCharset)) {
+            throw new InvalidUserDataException(String.format("Charset for contentCharset '%s' is not supported by your JVM", contentCharset));
+        }
+        this.internalManifest.contentCharset= contentCharset
+    }
+
+    @Override
     Manifest writeTo(Writer writer) {
         this.getEffectiveManifest().writeTo(writer)
+        return this
+    }
+
+    @Override
+    Manifest writeTo(OutputStream outputStream) {
+        this.getEffectiveManifest().writeTo(outputStream)
         return this
     }
 

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/file/TestFileHelper.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/file/TestFileHelper.groovy
@@ -1,7 +1,7 @@
 package com.github.jengelman.gradle.plugins.shadow.util.file;
 
 import org.apache.commons.io.FileUtils
-import org.apache.commons.lang.StringUtils
+import org.apache.commons.lang3.StringUtils
 import org.apache.tools.ant.Project
 import org.apache.tools.ant.taskdefs.Expand
 import org.apache.tools.ant.taskdefs.Tar

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/file/TestNameTestDirectoryProvider.java
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/file/TestNameTestDirectoryProvider.java
@@ -1,7 +1,7 @@
 package com.github.jengelman.gradle.plugins.shadow.util.file;
 
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.rules.MethodRule;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/repo/maven/MavenScope.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/repo/maven/MavenScope.groovy
@@ -1,6 +1,6 @@
 package com.github.jengelman.gradle.plugins.shadow.util.repo.maven
 
-import org.apache.commons.lang.StringUtils
+import org.apache.commons.lang3.StringUtils
 
 class MavenScope {
     Map<String, MavenDependency> dependencies = [:]


### PR DESCRIPTION
fix for #217: changes for Manifest on gradle side (version 2.14-rc-1) are propagated to shadow plugin