### PR TITLE
Add "zeroEntryTimestamps()" option

### DIFF
--- a/gradle/docs.gradle
+++ b/gradle/docs.gradle
@@ -1,5 +1,5 @@
 def javaApiUrl = 'http://docs.oracle.com/javase/1.7.0/docs/api'
-def groovyApiUrl = 'http://groovy.codehaus.org/gapi/'
+def groovyApiUrl = 'http://groovy-lang.org/api.html'
 
 tasks.withType(Javadoc) {
     classpath += project.configurations.shadow

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/PluginSpecification.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/PluginSpecification.groovy
@@ -2,6 +2,8 @@ package com.github.jengelman.gradle.plugins.shadow.util
 
 import com.github.jengelman.gradle.plugins.shadow.util.file.TestFile
 import com.google.common.base.StandardSystemProperty
+import org.apache.tools.zip.ZipEntry
+import org.apache.tools.zip.ZipFile
 import org.codehaus.plexus.util.IOUtil
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
@@ -98,6 +100,10 @@ class PluginSpecification extends Specification {
         is.close()
         jf.close()
         return sw.toString()
+    }
+
+    List<ZipEntry> getZipEntries(File f) {
+        new ZipFile(f).entries.toList()
     }
 
     void contains(File f, List<String> paths) {


### PR DESCRIPTION
See javadoc on the method for details on why and how. This
is basically the half-assed deterministic build from #229,
which is to say still extremely helpful when dealing with rsync.

Also update docs.gradle since doclet resolution freezes the build until the http request times out.
