### PR TITLE
Introduce keyTransformer property for PropertiesFileTransformer

### DIFF
--- a/src/docs/asciidoc/90-changes.adoc
+++ b/src/docs/asciidoc/90-changes.adoc
@@ -15,6 +15,7 @@
 * Build Shadow w/ Shadow. This will help prevent any future classpath conflicts with Gradle.
 * Replace `startShadowScripts` tasks with Gradle's built-in `CreateStartScripts` type.
 * Build with Gradle 3.1
+* https://github.com/marcphilipp[Marc Philipp] - Add `keyTransformer` property to `PropertiesFileTransformer`
 
 [discrete]
 === v1.2.4


### PR DESCRIPTION
The new keyTransformer property can be used to transform keys in properties files, e.g. because they contain class names about to be relocated. Its value can be set to a closure that receives the original key and returns the key name to be used in the resulting properties file.

We need this for junit-console-launcher because it uses joptsimple by @pholser which we want to relocate to a different package in order to enable users to test code that uses a different version of joptsimple. However, the joptsimple JAR contains properties files that contain keys that are class names.
