### PR TITLE
Making plugin with with Gradle 3.1 and non Maven projects

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.groovy
@@ -66,12 +66,15 @@ class ShadowJavaPlugin implements Plugin<Project> {
     private void configureShadowUpload() {
         configurationActionContainer.add(new Action<Project>() {
             public void execute(Project project) {
+                if (!project.plugins.hasPlugin(MavenPlugin)) {
+                    return
+                }
                 Upload upload = project.tasks.withType(Upload).findByName(SHADOW_UPLOAD_TASK)
                 if (!upload) {
                     return
                 }
                 upload.configuration = project.configurations.shadow
-                MavenPom pom = upload.repositories.mavenDeployer.pom
+                MavenPom pom = upload.repositories.mavenDeployer().pom
                 pom.scopeMappings.mappings.remove(project.configurations.compile)
                 pom.scopeMappings.mappings.remove(project.configurations.runtime)
                 pom.scopeMappings.addMapping(MavenPlugin.RUNTIME_PRIORITY, project.configurations.shadow, Conf2ScopeMappingContainer.RUNTIME)


### PR DESCRIPTION
Fixing issue where plugin would end up throwing 

```
Caused by: groovy.lang.MissingPropertyException: Could not get unknown property 'mavenDeployer' for repository container.
        at org.gradle.internal.metaobject.AbstractDynamicObject.getMissingProperty(AbstractDynamicObject.java:92)
        at org.gradle.internal.metaobject.AbstractDynamicObject.getProperty(AbstractDynamicObject.java:62)
        at org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler_Decorated.getProperty(Unknown Source)
        at com.github.jengelman.gradle.plugins.shadow.ShadowJavaPlugin$1.execute(ShadowJavaPlugin.groovy:74)
        at com.github.jengelman.gradle.plugins.shadow.ShadowJavaPlugin$1.execute(ShadowJavaPlugin.groovy)
        at org.gradle.configuration.project.DelayedConfigurationActions.execute(DelayedConfigurationActions.java:27)
        at org.gradle.configuration.project.DelayedConfigurationActions.execute(DelayedConfigurationActions.java:22)
```
