### PR TITLE
Fix class cast bug on gradle 3.x

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.groovy
@@ -54,7 +54,7 @@ class ShadowJavaPlugin implements Plugin<Project> {
                 manifest.attributes 'Class-Path': libs.findAll { it }.join(' ')
             }
         }
-        shadow.from(convention.sourceSets.main.output)
+        shadow.from(project.sourceSets.main.output)
         shadow.configurations = [project.configurations.runtime]
         shadow.exclude('META-INF/INDEX.LIST', 'META-INF/*.SF', 'META-INF/*.DSA', 'META-INF/*.RSA')
 


### PR DESCRIPTION
```
Caused by: java.lang.ClassCastException: org.gradle.api.plugins.JavaPluginConvention cannot be cast to groovy.lang.GroovyObject
        at org.codehaus.groovy.runtime.callsite.PogoGetPropertySite.getProperty(PogoGetPropertySite.java:50)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callGroovyObjectGetProperty(AbstractCallSite.java:307)
        at com.github.jengelman.gradle.plugins.shadow.ShadowJavaPlugin.configureShadowTask(ShadowJavaPlugin.groovy:57)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:497)
        at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite$PogoCachedMethodSiteNoUnwrapNoCoerce.invoke(PogoMetaMethodSite.java:210)
        at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite.callCurrent(PogoMetaMethodSite.java:59)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:52)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:154)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:166)
        at com.github.jengelman.gradle.plugins.shadow.ShadowJavaPlugin.apply(ShadowJavaPlugin.groovy:35)
        at com.github.jengelman.gradle.plugins.shadow.ShadowJavaPlugin.apply(ShadowJavaPlugin.groovy)
        at org.gradle.api.internal.plugins.ImperativeOnlyPluginApplicator.applyImperative(ImperativeOnlyPluginApplicator.java:35)
        at org.gradle.api.internal.plugins.RuleBasedPluginApplicator.applyImperative(RuleBasedPluginApplicator.java:43)
        at org.gradle.api.internal.plugins.DefaultPluginManager.doApply(DefaultPluginManager.java:137)
        ... 92 more
```