### PR TITLE
[RFC] Implemented JAR minimization

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -10,6 +10,7 @@ dependencies {
     compile 'commons-io:commons-io:2.5'
     compile 'org.apache.ant:ant:1.9.7'
     compile 'org.codehaus.plexus:plexus-utils:3.0.24'
+    compile 'org.vafer:jdependency:1.1'
 
     testCompile gradleTestKit()
     testCompile("org.spockframework:spock-core:1.0-groovy-2.4") {

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.groovy
@@ -47,6 +47,7 @@ class ShadowApplicationPlugin implements Plugin<Project> {
         jar.doFirst {
             manifest.attributes 'Main-Class': pluginConvention.mainClassName
         }
+        jar.entryPoint(pluginConvention.mainClassName)
     }
 
     protected void addRunTask(Project project) {

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/UnusedTracker.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/UnusedTracker.groovy
@@ -1,0 +1,56 @@
+package com.github.jengelman.gradle.plugins.shadow.internal
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.SourceSet
+import org.vafer.jdependency.Clazz
+import org.vafer.jdependency.Clazzpath
+import org.vafer.jdependency.ClazzpathUnit
+
+/** Tracks unused classes in the project classpath. */
+class UnusedTracker {
+    private final List<String> entryPoints
+    private final List<ClazzpathUnit> projectUnits
+    private final Clazzpath cp = new Clazzpath()
+
+    private UnusedTracker(List<File> classDirs, List<String> entryPoints) {
+        this.entryPoints = entryPoints
+        projectUnits = classDirs.collect { cp.addClazzpathUnit(it) }
+    }
+
+    Set<String> findUnused() {
+        Set<Clazz> unused = cp.clazzes
+
+        for (cpu in projectUnits) {
+            unused.removeAll(cpu.clazzes)
+            unused.removeAll(cpu.transitiveDependencies)
+        }
+
+        for (entryPoint in entryPoints) {
+            Clazz clazz = cp.getClazz(entryPoint)
+            if (clazz == null) {
+                throw new RuntimeException("Entry point not found: " + className);
+            }
+
+            unused.remove(clazz)
+            unused.removeAll(clazz.transitiveDependencies)
+        }
+
+        return unused.collect { it.name }.toSet()
+    }
+
+    void addDependency(File jarOrDir) {
+        cp.addClazzpathUnit(jarOrDir)
+    }
+
+    static UnusedTracker forProject(Project project, List<String> entryPoints) {
+        final List<File> classDirs = new ArrayList<>()
+        for (SourceSet sourceSet in project.sourceSets) {
+            File classDir = sourceSet.output.classesDir
+            if (classDir.isDirectory()) {
+                classDirs.add(classDir)
+            }
+        }
+
+        new UnusedTracker(classDirs, entryPoints)
+    }
+}

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowSpec.java
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowSpec.java
@@ -10,6 +10,11 @@ import org.gradle.api.Action;
 import org.gradle.api.file.CopySpec;
 
 interface ShadowSpec extends CopySpec {
+    void setMinimizeJar(boolean enabled);
+
+    boolean isMinimizeJar();
+
+    ShadowSpec entryPoint(String className);  // or reuse include?
 
     ShadowSpec dependencies(Action<DependencyFilter> configure);
 

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ApplicationSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ApplicationSpec.groovy
@@ -39,11 +39,11 @@ class ApplicationSpec extends PluginSpecification {
             apply plugin: 'application'
 
             mainClassName = 'myapp.Main'
-            
+
             dependencies {
                compile 'shadow:a:1.0'
             }
-            
+
             runShadow {
                args 'foo'
             }
@@ -100,11 +100,11 @@ class ApplicationSpec extends PluginSpecification {
             apply plugin: 'application'
 
             mainClassName = 'myapp.Main'
-            
+
             dependencies {
                shadow 'shadow:a:1.0'
             }
-            
+
             runShadow {
                args 'foo'
             }
@@ -150,11 +150,11 @@ class ApplicationSpec extends PluginSpecification {
             apply plugin: 'application'
 
             mainClassName = 'myapp.Main'
-            
+
             dependencies {
                compile 'shadow:a:1.0'
             }
-            
+
             runShadow {
                args 'foo'
             }

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/PluginSpecification.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/PluginSpecification.groovy
@@ -56,7 +56,7 @@ class PluginSpecification extends Specification {
         GradleRunner.create()
                 .withProjectDir(dir.root)
                 .forwardOutput()
-//                .withDebug(true)
+                .withDebug(true)
                 .withTestKitDir(getTestKitDir())
     }
 


### PR DESCRIPTION
This commit adds two new configuration options to the 'shadowJar' task.
When 'minimizeJar' is set the shadow JAR would only include the classes
for the project the task operates on and its dependencies. The user can
protect other classes from minimization by specifying them as entry
points.

Here's an example configuration

    shadowJar {
        minimizeJar = true
        entryPoint 'foo.Foo'
        entryPoint 'foo.Bar'
    }

N.B. imported but unused classes are not considered as dependencies. 

Closes #198 