### PR TITLE
Use dependency configurations introduced in Gradle 3.3 if possible

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.groovy
@@ -61,7 +61,8 @@ class ShadowJavaPlugin implements Plugin<Project> {
             }
         }
         shadow.from(convention.sourceSets.main.output)
-        shadow.configurations = [project.configurations.runtime]
+        shadow.configurations = [project.configurations.findByName('runtimeClasspath') ?
+                                         project.configurations.runtimeClasspath : project.configurations.runtime]
         shadow.exclude('META-INF/INDEX.LIST', 'META-INF/*.SF', 'META-INF/*.DSA', 'META-INF/*.RSA')
 
         PublishArtifact shadowArtifact = project.artifacts.add(ShadowBasePlugin.CONFIGURATION_NAME, shadow)


### PR DESCRIPTION
Fixes #275

Also properly ignore a long test of large ZIPs