### PR TITLE
Make build scan integration work with multi-project builds

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowPlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowPlugin.groovy
@@ -18,15 +18,16 @@ class ShadowPlugin implements Plugin<Project> {
             project.plugins.apply(ShadowApplicationPlugin)
         }
 
-        project.plugins.withId('com.gradle.build-scan') {
-            project.buildScan.buildFinished {
+        def rootProject = project.rootProject
+        rootProject.plugins.withId('com.gradle.build-scan') {
+            rootProject.buildScan.buildFinished {
                 def shadowTasks = project.tasks.withType(ShadowJar)
                 shadowTasks.each { task ->
                     if (task.didWork) {
                         task.stats.buildScanData.each { k, v ->
-                            project.buildScan.value "shadow.${task.name}.${k}", v.toString()
+                            rootProject.buildScan.value "shadow.${task.path}.${k}", v.toString()
                         }
-                        project.buildScan.value "shadow.${task.name}.configurations", task.configurations*.name.join(", ")
+                        rootProject.buildScan.value "shadow.${task.path}.configurations", task.configurations*.name.join(", ")
                     }
                 }
             }


### PR DESCRIPTION
The build scan plugin will only ever be applied to the root project. The current integration with the plugin assumes the project with the build scan plugin applied and the project with the shadow plugin applied are the same project. This will only ever be the case in a single-project build. In the case of a multi-project build these diverge.

Change the existing logic to look for the build-scan plugin on the root project, as well as include the complete task path in custom value keys as there exists the possibility that multiple `shadowJar` tasks exist within a single multi-project.