### PR TITLE
Fix SimpleWorkResult deprecation warning in gradle 4.2

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.groovy
@@ -31,6 +31,7 @@ import org.gradle.api.tasks.WorkResult
 import org.gradle.api.tasks.bundling.Zip
 import org.gradle.api.tasks.util.PatternSet
 import org.gradle.internal.UncheckedException
+import org.gradle.util.DeprecationLogger
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.ClassWriter
@@ -96,7 +97,12 @@ class ShadowCopyAction implements CopyAction {
                 )
             }
         }
-        return new SimpleWorkResult(true)
+
+        WorkResult result = null
+        DeprecationLogger.whileDisabled {
+            result = new SimpleWorkResult(true)
+        }
+        return result
     }
 
     private void processTransformers(ZipOutputStream stream) {


### PR DESCRIPTION
Explicitly silences deprecation warning regarding SimpleWorkResult.
Since the recommended WorkResults appeared in 4.2, we can use this
workaround to both avoid this warning in newer gradle versions and still
support pre-4.2 for now.

Closes #326.