### PR TITLE
update inputs.file to inputs.files, to remove warning

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.groovy
@@ -78,7 +78,7 @@ class ShadowApplicationPlugin implements Plugin<Project> {
         startScripts.conventionMapping.applicationName = { pluginConvention.applicationName }
         startScripts.conventionMapping.outputDir = { new File(project.buildDir, 'scriptsShadow') }
         startScripts.conventionMapping.defaultJvmOpts = { pluginConvention.applicationDefaultJvmArgs }
-        startScripts.inputs.file jar
+        startScripts.inputs.files jar
 
     }
 


### PR DESCRIPTION
Remove warning when using the shadow plugin:
`Using TaskInputs.file() with something that doesn't resolve to a File object has been deprecated and is scheduled to be removed in Gradle 5.0. Use TaskInputs.files() instead`