### PR TITLE
Help with 'java-gradle-plugin' without disabling `automatedPublishing`

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -17,5 +17,4 @@ dependencies {
     testCompile 'xmlunit:xmlunit:1.3'
     testCompile 'commons-lang:commons-lang:2.6'
     testCompile 'com.google.guava:guava:17.0'
-    testCompile 'org.apache.maven:maven-model:3.0.4'
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -17,4 +17,5 @@ dependencies {
     testCompile 'xmlunit:xmlunit:1.3'
     testCompile 'commons-lang:commons-lang:2.6'
     testCompile 'com.google.guava:guava:17.0'
+    testCompile 'org.apache.maven:maven-model:3.0.4'
 }

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowExtension.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowExtension.groovy
@@ -21,7 +21,7 @@ class ShadowExtension {
         publication.artifact(project.tasks.shadowJar)
         publication.pom { MavenPom pom ->
             pom.withXml { xml ->
-                def dependenciesNode = xml.asNode().appendNode('dependencies')
+                def dependenciesNode = xml.asNode().find { it.name() == 'dependencies' } ?: xml.asNode().appendNode('dependencies')
 
                 project.configurations.shadow.allDependencies.each {
                     if (! (it instanceof SelfResolvingDependency)) {

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/PluginShadowPluginSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/PluginShadowPluginSpec.groovy
@@ -1,7 +1,11 @@
 package com.github.jengelman.gradle.plugins.shadow
 
 import com.github.jengelman.gradle.plugins.shadow.util.PluginSpecification
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader //TODO delete me?
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.TaskOutcome
 
+import java.nio.file.Paths
 
 class PluginShadowPluginSpec extends PluginSpecification {
 
@@ -39,4 +43,93 @@ class PluginShadowPluginSpec extends PluginSpecification {
                 'shadow/junit/framework/TestSuite.class'
         ])
     }
+
+    /**
+     * In conjunction with the 'maven-publish' plugin, 'java-gradle-plugin' automatically creates some MavenPublications.
+     * <p>
+     * This test serves as an example of how to use {@link PluginShadowPlugin} without explicitly setting
+     * {@link org.gradle.plugin.devel.GradlePluginDevelopmentExtension#setAutomatedPublishing(boolean)} to false.
+     * <p>
+     * Note this also requires a small change in
+     * {@link ShadowExtension#component(org.gradle.api.publish.maven.MavenPublication)} to prevent it from adding a
+     * second {@literal `<dependencies>`} element when one was already created by the application of 'java-gradle-plugin'.
+     */
+    def "play nice with 'maven-publish' and 'java-gradle-plugin'"() {
+        given:
+        buildFile.text = buildFile.text.replace('com.github.johnrengelman.shadow', 'com.github.johnrengelman.plugin-shadow')
+        buildFile << """
+            apply plugin: 'maven-publish'
+            apply plugin: 'java-gradle-plugin'
+            
+            dependencies {
+                shadow 'junit:junit:3.8.2'
+            }
+            
+            gradlePlugin {
+                plugins {
+                    fake {
+                        id = 'com.acme.fake'
+                        implementationClass = 'com.acme.Fake'
+                    }
+                }
+            }
+            
+            // Remove the gradleApi so it isn't merged into the jar file.
+            configurations.compile.dependencies.remove dependencies.gradleApi()
+            
+            shadowJar {
+                classifier = ''
+            }
+                        
+            publishing {
+                publications {
+                    MavenPublication myPub = maybeCreate('pluginMaven', MavenPublication)
+                    project.shadow.component(myPub)
+                }
+            }
+        """.stripIndent()
+
+        when:
+        BuildResult result = runner.withArguments('shadowJar',
+                    'generatePomFileForPluginMavenPublication',
+                    'generatePomFileForFakePluginMarkerMavenPublication', '-s').build()
+
+        then:
+        result.task(':generatePomFileForPluginMavenPublication').outcome == TaskOutcome.SUCCESS
+        result.task(':generatePomFileForFakePluginMarkerMavenPublication').outcome == TaskOutcome.SUCCESS
+        result.task(':shadowJar').outcome == TaskOutcome.SUCCESS
+        File fatJarPomFile = Paths.get(dir.root.absolutePath, 'build', 'publications', 'pluginMaven', 'pom-default.xml').toFile()
+        File fakePluginMarker = Paths.get(dir.root.absolutePath, 'build', 'publications', 'fakePluginMarkerMaven', 'pom-default.xml').toFile()
+//        File fatJarWithoutClassifier = output() Paths.get(dir.root.absolutePath, 'build', 'libs', 'shadow-1.0.jar').toFile()
+        File fatJarWithoutClassifier = output('shadow-1.0.jar')
+        fatJarPomFile.exists()
+        fakePluginMarker.exists()
+        fatJarWithoutClassifier.exists()
+        isValid(fatJarPomFile)
+        isValid(fakePluginMarker)
+        dir
+    }
+
+    /**
+     * Simulates POM validation taking place during publish tasks, since invoking publishToMavenLocal seems to make
+     * TestKit hang.
+     * <p>
+     * Code is liberally borrowed from {@link org.gradle.api.publish.maven.internal.publisher.ValidatingMavenPublisher#readModelFromPom(File)}
+     * @param pomFile
+     * @return true if valid pom, false otherwise
+     */
+    private boolean isValid(File pomFile) {
+        FileReader reader = new FileReader(pomFile)
+        boolean result = false
+        try {
+            new MavenXpp3Reader().read(reader)
+            result = true
+        } catch (Exception e) {
+            e.printStackTrace()
+        } finally {
+            reader.close()
+        }
+        return result
+    }
+
 }


### PR DESCRIPTION
Hi @johnrengelman , nice to meet you.

First of all, don't merge this! The test is knowingly failing.

So, my use case that I have a several collections of gradle plugins and I want to shadow their transitive dependencies to avoid buildscript classpath wonkiness (damn you, guava). I also strongly prefer to leverage the implicit publications generated by `java-gradle-plugin` when we leave the `automatedPublishing` property of GradlePluginDevelopmentExtension as its default (true). Interestingly, some of the workarounds[1] to being able to apply the `java-gradle-plugin` came from this project's build itself.

Ultimately, though, I think I've hit a wall. The way the software model rules are configured in `o.g.plugin.devel.plugins.MavenPluginPublishingRules`, there's not a way I can see to avoid adding both the un-shadowed JAR and the shadowed JAR as artifacts. I'm curious if you've run in to this and if you have any thoughts or examples on how we might work around this.

[1] Basically I have to do four things to a plugin's build to be able to use `java-gradle-plugin`:
1. Remove `gradleApi` from compile configuration
2. Remove the shadowJar's `-all` classifier
3. Call `maybeCreate('pluginMaven')` inside the PublishingContainer to avoid a conflict
4. Call component method on `ShadowExtension` (requires my fix to reuse the <dependencies> node, if it already exists. I believe this is the same symptom shown by #306 )