### PR TITLE
Upgrade ASM to 6.2 (JDK 11 support)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -5,8 +5,8 @@ dependencies {
     shadow 'org.codehaus.groovy:groovy-backports-compat23:2.4.4'
 
     compile 'org.jdom:jdom2:2.0.6'
-    compile 'org.ow2.asm:asm:6.1.1'
-    compile 'org.ow2.asm:asm-commons:6.1.1'
+    compile 'org.ow2.asm:asm:6.2'
+    compile 'org.ow2.asm:asm-commons:6.2'
     compile 'commons-io:commons-io:2.5'
     compile 'org.apache.ant:ant:1.9.7'
     compile 'org.codehaus.plexus:plexus-utils:3.0.24'


### PR DESCRIPTION
ASM 6.2 brings support for JDK11, http://asm.ow2.io/versions.html. 

Without this builds are failing with:
```
Caused by: java.lang.IllegalArgumentException: Unsupported class file major version 55
	at shadow.org.objectweb.asm.ClassReader.<init>(ClassReader.java:166)
	at shadow.org.objectweb.asm.ClassReader.<init>(ClassReader.java:148)
	at shadow.org.objectweb.asm.ClassReader.<init>(ClassReader.java:136)
	at shadow.org.objectweb.asm.ClassReader.<init>(ClassReader.java:237)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
	at org.codehaus.groovy.reflection.CachedConstructor.invoke(CachedConstructor.java:83)
	at org.codehaus.groovy.runtime.callsite.ConstructorSite$ConstructorSiteNoUnwrapNoCoerce.callConstructor(ConstructorSite.java:105)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallConstructor(CallSiteArray.java:60)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:235)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:247)
	at com.github.jengelman.gradle.plugins.shadow.tasks.ShadowCopyAction$StreamAction.remapClass(ShadowCopyAction.groovy:269)
```