### PR TITLE
Implemented JAR minimization

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -10,6 +10,7 @@ dependencies {
     compile 'commons-io:commons-io:2.5'
     compile 'org.apache.ant:ant:1.9.7'
     compile 'org.codehaus.plexus:plexus-utils:3.0.24'
+    compile 'org.vafer:jdependency:1.3'
 
     testCompile("org.spockframework:spock-core:1.0-groovy-2.4") {
         exclude module: 'groovy-all'

--- a/src/docs/asciidoc/10-configuring.adoc
+++ b/src/docs/asciidoc/10-configuring.adoc
@@ -100,3 +100,5 @@ include::12-controlling-dependencies.adoc[]
 include::13-controlling-merging.adoc[]
 
 include::14-package-relocation.adoc[]
+
+include::15-minimizing.adoc[]

--- a/src/docs/asciidoc/15-minimizing.adoc
+++ b/src/docs/asciidoc/15-minimizing.adoc
@@ -1,0 +1,23 @@
+=== Minimizing
+
+Shade can automatically remove all classes of dependencies that are not used by the project, thereby minimizing the resulting uber JAR.
+
+.Minimizing an uber JAR
+[source,groovy,indent=0]
+----
+shadowJar {
+  minimize()
+}
+----
+
+A dependency can be excluded from this process. This is useful when some classes are considered as not used whereas they are, for example via `Class.forName(String)`.
+
+.Enforcing the presence of the classes of a dependency
+[source,groovy,indent=0]
+----
+shadowJar {
+  minimize {
+    exclude(dependency('org.scala-lang:.*:.*'))
+  }
+}
+----

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/UnusedTracker.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/UnusedTracker.groovy
@@ -1,0 +1,44 @@
+package com.github.jengelman.gradle.plugins.shadow.internal
+
+import org.gradle.api.Project
+import org.gradle.api.file.FileCollection
+import org.gradle.api.tasks.SourceSet
+import org.vafer.jdependency.Clazz
+import org.vafer.jdependency.Clazzpath
+import org.vafer.jdependency.ClazzpathUnit
+
+/** Tracks unused classes in the project classpath. */
+class UnusedTracker {
+    private final FileCollection toMinimize
+    private final List<ClazzpathUnit> projectUnits
+    private final Clazzpath cp = new Clazzpath()
+
+    private UnusedTracker(List<File> classDirs, FileCollection toMinimize) {
+        this.toMinimize = toMinimize
+        projectUnits = classDirs.collect { cp.addClazzpathUnit(it) }
+    }
+
+    Set<String> findUnused() {
+        Set<Clazz> unused = cp.clazzes
+        for (cpu in projectUnits) {
+            unused.removeAll(cpu.clazzes)
+            unused.removeAll(cpu.transitiveDependencies)
+        }
+        return unused.collect { it.name }.toSet()
+    }
+
+    void addDependency(File jarOrDir) {
+        if (toMinimize.contains(jarOrDir)) {
+            cp.addClazzpathUnit(jarOrDir)
+        }
+    }
+
+    static UnusedTracker forProject(Project project, FileCollection toMinimize) {
+        final List<File> classDirs = new ArrayList<>()
+        for (SourceSet sourceSet in project.sourceSets) {
+            Iterable<File> classesDirs = sourceSet.output.hasProperty('classesDirs') ? sourceSet.output.classesDirs : [sourceSet.output.classesDir]
+            classDirs.addAll(classesDirs.findAll { it.isDirectory() })
+        }
+        return new UnusedTracker(classDirs, toMinimize)
+    }
+}

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowSpec.java
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowSpec.java
@@ -10,6 +10,9 @@ import org.gradle.api.Action;
 import org.gradle.api.file.CopySpec;
 
 interface ShadowSpec extends CopySpec {
+    ShadowSpec minimize();
+
+    ShadowSpec minimize(Action<DependencyFilter> configureClosure);
 
     ShadowSpec dependencies(Action<DependencyFilter> configure);
 


### PR DESCRIPTION
(this is a follow up of https://github.com/johnrengelman/shadow/pull/273)

This commit adds two new configuration options to the 'shadowJar' task.
When 'minimize' is set the shadow JAR would only include the classes
for the project the task operates on and its dependencies. The user can
protect other classes from minimization by excluding their module.

Here's an example configuration

    shadowJar {
      minimize {
        exclude(dependency('junit:junit:.*'))
      }
    }