### PR TITLE
Support AbstractArchiveTask.preserveFileTimestamps for reproducible builds

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.java
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.java
@@ -63,7 +63,7 @@ public class ShadowJar extends Jar implements ShadowSpec {
         DocumentationRegistry documentationRegistry = getServices().get(DocumentationRegistry.class);
         return new ShadowCopyAction(getArchivePath(), getInternalCompressor(), documentationRegistry,
                 this.getMetadataCharset(), transformers, relocators, getRootPatternSet(), shadowStats,
-                versionUtil);
+                versionUtil, isPreserveFileTimestamps());
     }
 
     @Internal

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowPluginSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowPluginSpec.groovy
@@ -86,7 +86,7 @@ class ShadowPluginSpec extends PluginSpecification {
         assert output.exists()
 
         where:
-        version << ['3.0', '3.1', '3.2', '3.3', '3.4', '3.5', '4.0', '4.1', '4.2', '4.3', '4.4', '4.5', '4.6']
+        version << ['3.4', '3.5', '4.0', '4.1', '4.2', '4.3', '4.4', '4.5', '4.6']
     }
 
     def 'Error in Gradle versions < 3.0'() {


### PR DESCRIPTION
With this PR, the [officially recommended Gradle config for reproducible builds](https://docs.gradle.org/4.8/userguide/working_with_files.html#sec:reproducible_archives) now successfully creates reproducible builds when used with shadowJar:

```
tasks.withType(AbstractArchiveTask) {
    preserveFileTimestamps = false
    reproducibleFileOrder = true
}
```

Gradle 3.4 added support for reproducible builds of archives, but shadowJar doesn't respect the preserveFileTimestamps setting despite extending AbstractArchiveTask which exposes that. This PR makes the shadowJar task handle the preserveFileTimestamps setting. (I believe the reproducibleFileOrder setting is handled by Gradle in a way that already works for shadowJar.)

Solves https://github.com/johnrengelman/shadow/issues/229 and https://github.com/johnrengelman/shadow/issues/389.

The implementation and choice of the default constant timestamp are inspired by Gradle's own ZipCopyAction class.

This does make the plugin incompatible with versions of Gradle before 3.4. I think I could change the PR to use reflection to read the preserveFileTimestamps value if backwards compatibility with those versions was considered important.

I know that the inspiration for https://github.com/johnrengelman/shadow/pull/333 was to allow a user to configure build.gradle to zero out timestamps, but I don't think this PR is redundant with it: this PR adds support to shadowJar for the standard Gradle configuration for reproducible builds without adding any new shadow APIs.