### PR TITLE
Migrating Maven transformer to Gradle.

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -10,6 +10,7 @@ dependencies {
     compile 'commons-io:commons-io:2.5'
     compile 'org.apache.ant:ant:1.9.7'
     compile 'org.codehaus.plexus:plexus-utils:3.0.24'
+    compile "org.apache.logging.log4j:log4j-core:2.11.0"
 
     testCompile("org.spockframework:spock-core:1.0-groovy-2.4") {
         exclude module: 'groovy-all'

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2PluginsCacheFileTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2PluginsCacheFileTransformer.groovy
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License") you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.github.jengelman.gradle.plugins.shadow.transformers
+
+import com.github.jengelman.gradle.plugins.shadow.ShadowStats
+import com.github.jengelman.gradle.plugins.shadow.relocation.RelocateClassContext
+import com.github.jengelman.gradle.plugins.shadow.relocation.Relocator
+import org.apache.commons.io.IOUtils
+import org.apache.commons.io.output.CloseShieldOutputStream
+import org.apache.logging.log4j.core.config.plugins.processor.PluginCache
+import org.apache.logging.log4j.core.config.plugins.processor.PluginEntry
+import org.apache.tools.zip.ZipOutputStream
+import org.gradle.api.file.FileTreeElement
+
+import java.util.zip.ZipEntry
+
+import static org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor.PLUGIN_CACHE_FILE;
+
+/**
+ * Modified from the maven equivalent to work with gradle
+ *
+ * @author Paul Nelson Baker
+ * @see <a href="https://www.linkedin.com/in/paul-n-baker/">LinkedIn</a>
+ * @see <a href="https://github.com/paul-nelson-baker/">GitHub</a>
+ * @see <a href="https://github.com/edwgiz/maven-shaded-log4j-transformer">edwgiz/maven-shaded-log4j-transformer</a>
+ * @see <a href="https://github.com/edwgiz/maven-shaded-log4j-transformer/blob/master/src/main/java/com/github/edwgiz/mavenShadePlugin/log4j2CacheTransformer/PluginsCacheFileTransformer.java">PluginsCacheFileTransformer.java</a>
+ */
+class Log4j2PluginsCacheFileTransformer implements Transformer {
+
+    private final List<File> temporaryFiles;
+    private final List<Relocator> relocators;
+
+    public Log4j2PluginsCacheFileTransformer() {
+        temporaryFiles = new ArrayList<>();
+        relocators = new ArrayList<>();
+    }
+
+    @Override
+    boolean canTransformResource(FileTreeElement element) {
+        return PLUGIN_CACHE_FILE == element.name
+    }
+
+    @Override
+    void transform(TransformerContext context) {
+        def inputStream = context.is
+        def temporaryFile = File.createTempFile("Log4j2Plugins", ".dat")
+        temporaryFile.deleteOnExit()
+        temporaryFiles.add(temporaryFile)
+        IOUtils.copy(inputStream, new FileOutputStream(temporaryFile))
+        def contextRelocators = context.relocators
+        if (contextRelocators != null) {
+            this.relocators.addAll(contextRelocators)
+        }
+    }
+
+    @Override
+    boolean hasTransformedResource() {
+        // This functionality matches the original plugin, however, I'm not clear what
+        // the exact logic is. From what I can tell temporaryFiles should be never be empty
+        // if anything has been performed.
+        def hasTransformedMultipleFiles = temporaryFiles.size() > 1
+        def hasAtLeastOneFileAndRelocator = !temporaryFiles.isEmpty() && !relocators.isEmpty()
+        def hasTransformedResources = hasTransformedMultipleFiles || hasAtLeastOneFileAndRelocator
+        return hasTransformedResources
+    }
+
+    @Override
+    void modifyOutputStream(ZipOutputStream jos) {
+        PluginCache pluginCache = new PluginCache()
+        pluginCache.loadCacheFiles(getUrlEnumeration())
+        relocatePlugins(pluginCache)
+        zipOutputStream.putNextEntry(new ZipEntry(PLUGIN_CACHE_FILE))
+        pluginCache.writeCache(new CloseShieldOutputStream(zipOutputStream))
+        temporaryFiles.clear()
+    }
+
+    private Enumeration<URL> getUrlEnumeration() {
+        def urls = temporaryFiles.collect({ it.toURL() }).asList()
+        return Collections.enumeration(urls)
+    }
+
+    private void relocatePlugins(PluginCache pluginCache) {
+        for (Map<String, PluginEntry> currentMap : pluginCache.getAllCategories().values()) {
+            pluginEntryLoop:
+            for (PluginEntry currentPluginEntry : currentMap.values()) {
+                String className = currentPluginEntry.getClassName();
+                RelocateClassContext relocateClassContext = new RelocateClassContext(className, new ShadowStats());
+                for (Relocator currentRelocator : relocators) {
+                    // If we have a relocator that can relocate our current entry...
+                    boolean canRelocateClass = currentRelocator.canRelocateClass(relocateClassContext);
+                    if (canRelocateClass) {
+                        // Then we perform that relocation and update the plugin entry to reflect the new value.
+                        String relocatedClassName = currentRelocator.relocateClass(relocateClassContext);
+                        currentPluginEntry.setClassName(relocatedClassName);
+                        continue pluginEntryLoop;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2PluginsCacheFileTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2PluginsCacheFileTransformer.groovy
@@ -26,10 +26,9 @@ import org.apache.commons.io.IOUtils
 import org.apache.commons.io.output.CloseShieldOutputStream
 import org.apache.logging.log4j.core.config.plugins.processor.PluginCache
 import org.apache.logging.log4j.core.config.plugins.processor.PluginEntry
+import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
 import org.gradle.api.file.FileTreeElement
-
-import java.util.zip.ZipEntry
 
 import static org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor.PLUGIN_CACHE_FILE;
 
@@ -82,7 +81,7 @@ class Log4j2PluginsCacheFileTransformer implements Transformer {
     }
 
     @Override
-    void modifyOutputStream(ZipOutputStream jos) {
+    void modifyOutputStream(ZipOutputStream zipOutputStream) {
         PluginCache pluginCache = new PluginCache()
         pluginCache.loadCacheFiles(getUrlEnumeration())
         relocatePlugins(pluginCache)

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2PluginsCacheFileTransformerTest.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2PluginsCacheFileTransformerTest.groovy
@@ -1,0 +1,81 @@
+package com.github.jengelman.gradle.plugins.shadow.transformers
+
+import com.github.jengelman.gradle.plugins.shadow.relocation.Relocator
+import com.github.jengelman.gradle.plugins.shadow.relocation.SimpleRelocator
+import org.apache.tools.zip.ZipOutputStream
+import org.junit.Before
+import org.junit.Test
+
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+
+import static java.util.Collections.singletonList
+import static org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor.PLUGIN_CACHE_FILE
+
+/**
+ * @author Paul Nelson Baker
+ * @since 2018-08
+ * @see <a href="https://github.com/paul-nelson-baker/">GitHub</a>
+ * @see <a href="https://www.linkedin.com/in/paul-n-baker/">LinkedIn</a>
+ */
+//@RunWith(Parameterized.class)
+class Log4j2PluginsCacheFileTransformerTest {
+
+    Log4j2PluginsCacheFileTransformer transformer
+
+    @Before
+    void setUp() {
+        transformer = new Log4j2PluginsCacheFileTransformer()
+    }
+
+    @Test
+    void testShouldNotTransform() {
+        transformer.transform(new TransformerContext(PLUGIN_CACHE_FILE, getResourceStream(PLUGIN_CACHE_FILE), null))
+        assertFalse(transformer.hasTransformedResource())
+    }
+
+    @Test
+    void testShouldTransform() {
+        List<Relocator> relocators = new ArrayList<>()
+        relocators.add(new SimpleRelocator(null, null, null, null))
+        transformer.transform(new TransformerContext(PLUGIN_CACHE_FILE, getResourceStream(PLUGIN_CACHE_FILE), relocators))
+        assertTrue(transformer.hasTransformedResource())
+    }
+
+    @Test
+    void testRelocators() {
+        testRelocate("org.apache.logging", "new.location.org.apache.logging", "new.location.org.apache.logging")
+        testRelocate("org.apache.logging", "new.location.org.apache.logging", "org.apache.logging")
+    }
+
+    void testRelocate(String source, String pattern, String target) throws IOException {
+        List<Relocator> relocators = singletonList((Relocator) new SimpleRelocator(source, pattern, null, null))
+        transformer.transform(new TransformerContext(PLUGIN_CACHE_FILE, getResourceStream(PLUGIN_CACHE_FILE), relocators))
+        assertTrue(transformer.hasTransformedResource(), "Transformer didn't transform resources")
+        // Write out to a fake jar file
+        File.createTempFile("testable-zip-file-", ".jar").withCloseable { testableZipFile ->
+            new FileOutputStream(testableZipFile).withCloseable { fileOutputStream ->
+                new BufferedOutputStream(fileOutputStream).withCloseable { bufferedOutputStream ->
+                    new ZipOutputStream(bufferedOutputStream).withCloseable { zipOutputStream ->
+                        transformer.modifyOutputStream(zipOutputStream)
+                    }
+                }
+            }
+        }
+        // Pull the data back out and make sure it was transformed
+        ZipFile zipFile = new ZipFile(testableZipFile)
+        ZipEntry zipFileEntry = zipFile.getEntry(PLUGIN_CACHE_FILE)
+        InputStream inputStream = zipFile.getInputStream(zipFileEntry)
+        new Scanner(inputStream).withReader { scanner ->
+            boolean hasAtLeastOneTransform = false
+            while (scanner.hasNextLine()) {
+                String nextLine = scanner.nextLine()
+                if (nextLine.contains(source)) {
+                    hasAtLeastOneTransform = true
+                    assertTrue(nextLine.contains(target), "Target wasn't included in transform")
+                }
+            }
+            assertTrue(hasAtLeastOneTransform, "There were no transformations inside the file")
+        }
+    }
+}


### PR DESCRIPTION
I originally wrote this in its own plugin which attached itself to the shadow plugin. It's better to bundle the transformer into the shadow plugin inself instead of my own orthoginal plugin.

https://issues.apache.org/jira/browse/LOG4J2-673
https://github.com/paul-nelson-baker/gradle-shaded-log4j2-cachefile-transformer/blob/master/src/main/java/io/paulbaker/gradle/shadow/transform/Log4j2PluginsCacheFileTransformer.java
https://github.com/edwgiz/maven-shaded-log4j-transformer/blob/master/src/main/java/com/github/edwgiz/mavenShadePlugin/log4j2CacheTransformer/PluginsCacheFileTransformer.java