### PR TITLE
Upgrade ASM to 7.0-beta and jdependency to 2.1.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -5,13 +5,13 @@ dependencies {
     shadow 'org.codehaus.groovy:groovy-backports-compat23:2.4.15'
 
     compile 'org.jdom:jdom2:2.0.6'
-    compile 'org.ow2.asm:asm:6.2.1'
-    compile 'org.ow2.asm:asm-commons:6.2.1'
+    compile 'org.ow2.asm:asm:7.0-beta'
+    compile 'org.ow2.asm:asm-commons:7.0-beta'
     compile 'commons-io:commons-io:2.5'
     compile 'org.apache.ant:ant:1.9.7'
     compile 'org.codehaus.plexus:plexus-utils:3.0.24'
     compile "org.apache.logging.log4j:log4j-core:2.11.0"
-    compile('org.vafer:jdependency:1.3') {
+    compile('org.vafer:jdependency:2.1.1') {
         exclude group: 'org.ow2.asm'
     }
 


### PR DESCRIPTION
Just a dependencies upgrade that resolves the `java.lang.UnsupportedOperationException: This feature requires ASM7` error when using JDK 11.

As a side note, upgrades to `org.ow2.asm` would almost always require an upgrade
of the `jdependency` lib, where the newest ASM opt codes are supported.

--------

Resolves #406