### PR TITLE
Avoid leaking plugin classes into Gradle's pattern spec result cache

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.groovy
@@ -20,6 +20,7 @@
 package com.github.jengelman.gradle.plugins.shadow.transformers
 
 import com.github.jengelman.gradle.plugins.shadow.relocation.RelocateClassContext
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowCopyAction
 import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
 import org.gradle.api.file.FileTreeElement
@@ -59,7 +60,8 @@ class ServiceFileTransformer implements Transformer, PatternFilterable {
 
     @Override
     boolean canTransformResource(FileTreeElement element) {
-        return patternSet.asSpec.isSatisfiedBy(element)
+        FileTreeElement target = element instanceof ShadowCopyAction.ArchiveFileTreeElement ? element.asFileTreeElement() : element
+        return patternSet.asSpec.isSatisfiedBy(target)
     }
 
     @Override


### PR DESCRIPTION
This pull request fixes some memory leak issues we noticed when using the Shadow plugin with long lived Gradle daemons. The commit addresses two items:

1. `RelativeArchivePath` was unnecessarily keeping a reference to `DefaultFileCopyDetails` which is a pretty heavyweight object. Turns out this is never actually used so this has been removed.

2. The whole reason item (1) was an issue was is because results of calls to pattern specs are actually [cached](https://github.com/gradle/gradle/blob/master/subprojects/core-api/src/main/java/org/gradle/api/tasks/util/internal/CachingPatternSpecFactory.java#L63) by Gradle, such as [this one](https://github.com/johnrengelman/shadow/blob/master/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.groovy#L260). The cache computes a key based on this `RelativeArchivePath`, therefore instances of those stay in memory. Making those instances lighter (by removing the reference to `FileCopyDetails`) helps here but the root cause is that the daemon keeps strong references back to plugin classes, and therefore, their classloader. When changes to `buildSrc` happen these old classloaders pile up, as we cannot garbage collect them due to these cache references. The solution here is to not use non-core types in these caches at all, thus the addition of `getAsFileTreeElement()` to `ArchiveFileTreeElement`. This avoids the need to pass `ArchiveFileTreeElement` directly to `isSatisfiedBy()` and thereby ensuring no classes from this plugin leak into the pattern set result caches.