### PR TITLE
Remove ShadowJar MetaClass implementation. Fix for gradle 5.2

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.java
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.java
@@ -347,31 +347,4 @@ public class ShadowJar extends Jar implements ShadowSpec {
     public void setDependencyFilter(DependencyFilter filter) {
         this.dependencyFilter = filter;
     }
-
-    // This code is only to make IntelliJ happy.
-    private transient MetaClass metaClass = InvokerHelper.getMetaClass(this.getClass());
-
-    public Object getProperty(String property) {
-        return this.getMetaClass().getProperty(this, property);
-    }
-
-    public void setProperty(String property, Object newValue) {
-        this.getMetaClass().setProperty(this, property, newValue);
-    }
-
-    public Object invokeMethod(String name, Object args) {
-        return this.getMetaClass().invokeMethod(this, name, args);
-    }
-
-    public MetaClass getMetaClass() {
-        if(this.metaClass == null) {
-            this.metaClass = InvokerHelper.getMetaClass(this.getClass());
-        }
-
-        return this.metaClass;
-    }
-
-    public void setMetaClass(MetaClass metaClass) {
-        this.metaClass = metaClass;
-    }
 }


### PR DESCRIPTION
 As I tested the plugin with gradle 5.2 I got an error. Gradle was unable to create the shadowJar task because of duplicate metaClass methods. Not sure if we really have to remove it here or it's more a problem of gradle.