### PR TITLE
Add automatic handling of Gradle API when using java-gradle-plugin

### DIFF
--- a/src/docs/configuration/relocation/README.md
+++ b/src/docs/configuration/relocation/README.md
@@ -71,6 +71,7 @@ tasks.shadowJar.dependsOn tasks.relocateShadowJar
 
 > Configuring package auto relocation can add significant time to the shadow process as it will process all dependencies
 in the configurations declared to be shadowed. By default, this is the `runtime` or `runtimeClasspath` configurations.
-Be mindful that some Gradle plugins (such as `java-gradle-plugin` will automatically add dependencies to your class path
-(e.g. `java-gradle-plugin` automatically adds the full Gradle API to your `compile` configuratinon. You may need to
-remove these dependencies if you do not intend to shadow them into your library.
+Be mindful that some Gradle plugins will automatically add dependencies to your class path. You may need to remove these 
+dependencies if you do not intend to shadow them into your library.  The `java-gradle-plugin` would normally cause such
+problems if it were not for the special handling that Shadow provides as described in 
+[Special Handling of the Java Gradle Plugin Development Plugin](/plugins/#special-handling-of-the-java-gradle-plugin-gevelopmeny-plugin).

--- a/src/docs/plugins/README.md
+++ b/src/docs/plugins/README.md
@@ -49,3 +49,13 @@ Note that the `localGroovy()` and `gradleApi()` dependencies are added to the `s
 normal `compile` configuration. These 2 dependencies are provided by Gradle to compile your project but are ultimately
 provided by the Gradle runtime when executing the plugin. Thus, it is **not** advisable to bundle these dependencies
 with your plugin.
+
+## Special Handling of the Java Gradle Plugin Development Plugin
+
+The Java Gradle Plugin Development plugin, `java-gradle-plugin`, automatically adds the full Gradle API to the `compile` 
+configuration; thus overriding a possible assignment of `gradleApi()` to the `shadow` configuration.  Since it is never
+a good idea to include the Gradle API when creating a Gradle plugin, the dependency is removed so that it is not 
+included in the resultant shadow jar.  Virtually:
+
+    // needed to prevent inclusion of gradle-api into shadow JAR
+    configurations.compile.dependencies.remove dependencies.gradleApi()


### PR DESCRIPTION
The Java Gradle Plugin Development plugin, `java-gradle-plugin`,
automatically adds the full Gradle API to the `compile` configuration;
thus overriding a possible assignment of `gradleApi()` to the `shadow`
configuration.  Since it is never a good idea to include the Gradle API
when creating a Gradle plugin, the dependency is removed so that it is
not included in the resultant shadow jar.