### PR TITLE
Fix for com.palantir.docker interoperability.

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.groovy
@@ -43,8 +43,10 @@ class ShadowApplicationPlugin implements Plugin<Project> {
         project.plugins.withType(MavenPlugin) {
             project.configurations.archives.with {
                 artifacts.findAll {
-                    it.provider.get().is(project.tasks.shadowDistZip) ||
-                            it.provider.get().is(project.tasks.shadowDistTar)
+                    if (it.hasProperty("provider")) {
+                        it.provider.get().is(project.tasks.shadowDistZip) ||
+                                it.provider.get().is(project.tasks.shadowDistTar)
+                    }
                 }.each {
                     artifacts.remove it
                 }


### PR DESCRIPTION
This patch fixes a problem when `application`, `shadow` and
`com.palantir.docker` plugins are activated at the same time.

Exception:

```
An exception occurred applying plugin request [id: 'application']
> Failed to apply plugin [class
'com.github.jengelman.gradle.plugins.shadow.ShadowApplicationPlugin']
   > No such property: provider for class:
org.gradle.api.internal.artifacts.publish.ArchivePublishArtifact
```