### PR TITLE
Improve cache effectives for inputs to ShadowJar task

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.java
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.java
@@ -330,7 +330,7 @@ public class ShadowJar extends Jar implements ShadowSpec {
         this.relocators = relocators;
     }
 
-    @InputFiles @Optional
+    @Internal("tracked by includedDependencies")
     public List<Configuration> getConfigurations() {
         return this.configurations;
     }


### PR DESCRIPTION
`ShadowJar` has currently two important inputs. https://github.com/johnrengelman/shadow/blob/master/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.java#L333-L336 and https://github.com/johnrengelman/shadow/blob/master/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.java#L98-L107

The `getIncludedDependencies` is actually derived from the `getConfigurations` The derivation process is the application of filters. I'm working on a use case described in #443. I have a multi-module project. One module produces two shadow jar. One is including classes from all submodules the other is including dependencies. In a configuration of shadow jar, I'm doing to achieve that result:
```
shadowJar {
    configurations = [configurations.runtime]
    dependencies {
        exclude(project(':common-submodule'))
    }
}
```
There is a lot of dependencies and the creation of dependencies jar should not be done unless it is necessary. Unfortunately, when I change the code in `common-submodule` it generates a new jar which leads to modification of `configurations.runtime` and because `getConfigurations` is marked as `@InputFiles` it invalidates task cache ant retriggers the execution. It could be avoided because the changed jar is filtered out from the configuration and final result of `getIncludedDependencies` would be unchanged.

I would like to propose marking `getConfigurations` as `@Internal` leaving only the final result of filtering as cached. It would help avoid cache invalidation. I talked to Gradle team to double check that I'm not doing anything unexpected from Gradle point of view and I was told this is quite a common pattern even in Gradle itself.