### PR TITLE
Add ManifestAppenderTransformer to support sealing packages in jars.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,8 @@ test {
         minHeapSize "1g"
         maxHeapSize "1g"
     }
+    
+    systemProperty 'java.io.tmpdir', buildDir.absolutePath
 }
 
 jar {

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.groovy
@@ -12,9 +12,14 @@ class ManifestAppenderTransformer implements Transformer {
     private static final byte[] EOL = "\r\n".getBytes(UTF_8)
     private static final byte[] SEPARATOR = ": ".getBytes(UTF_8)
 
-    private byte[] manifestContents
+    private byte[] manifestContents = []
+    private final List<Tuple2<String, ? extends Comparable<?>>> attributes = []
 
-    List<Tuple2<String, ? extends Comparable<?>>> attributes = []
+    List<Tuple2<String, ? extends Comparable<?>>> getAttributes() { attributes }
+
+    boolean attribute(String name, Comparable<?> value) {
+        attributes.add(new Tuple2<String, ? extends Comparable<?>>(name, value))
+    }
 
     @Override
     boolean canTransformResource(FileTreeElement element) {

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.groovy
@@ -1,0 +1,53 @@
+package com.github.jengelman.gradle.plugins.shadow.transformers
+
+import org.apache.tools.zip.ZipEntry
+import org.apache.tools.zip.ZipOutputStream
+import org.codehaus.plexus.util.IOUtil
+import org.gradle.api.file.FileTreeElement
+
+import static java.nio.charset.StandardCharsets.*
+import static java.util.jar.JarFile.*
+
+class ManifestAppenderTransformer implements Transformer {
+    private static final byte[] EOL = "\r\n".getBytes(UTF_8)
+    private static final byte[] SEPARATOR = ": ".getBytes(UTF_8)
+
+    private byte[] manifestContents
+
+    List<Tuple2<String, ? extends Comparable<?>>> attributes = []
+
+    @Override
+    boolean canTransformResource(FileTreeElement element) {
+        MANIFEST_NAME.equalsIgnoreCase(element.relativePath.pathString)
+    }
+
+    @Override
+    void transform(TransformerContext context) {
+        manifestContents = IOUtil.toByteArray(context.is)
+        IOUtil.close(context.is)
+    }
+
+    @Override
+    boolean hasTransformedResource() {
+        !attributes.isEmpty()
+    }
+
+    @Override
+    void modifyOutputStream(ZipOutputStream os, boolean preserveFileTimestamps) {
+        ZipEntry entry = new ZipEntry(MANIFEST_NAME)
+        entry.time = TransformerContext.getEntryTimestamp(preserveFileTimestamps, entry.time)
+        os.putNextEntry(entry)
+        os.write(manifestContents)
+
+        if (!attributes.isEmpty()) {
+            for (attribute in attributes) {
+                os.write(attribute.first.getBytes(UTF_8))
+                os.write(SEPARATOR)
+                os.write(attribute.second.toString().getBytes(UTF_8))
+                os.write(EOL)
+            }
+            os.write(EOL)
+            attributes.clear()
+        }
+    }
+}

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.groovy
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License") you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.github.jengelman.gradle.plugins.shadow.transformers
 
 import org.apache.tools.zip.ZipEntry
@@ -8,6 +27,14 @@ import org.gradle.api.file.FileTreeElement
 import static java.nio.charset.StandardCharsets.*
 import static java.util.jar.JarFile.*
 
+/**
+ * A resource processor that can append arbitrary attributes to the first MANIFEST.MF
+ * that is found in the set of JARs being processed. The attributes are appended in
+ * the specified order, and duplicates are allowed.
+ * <p>
+ * Modified from {@link ManifestResourceTransformer}.
+ * @author Chris Rankin
+ */
 class ManifestAppenderTransformer implements Transformer {
     private static final byte[] EOL = "\r\n".getBytes(UTF_8)
     private static final byte[] SEPARATOR = ": ".getBytes(UTF_8)
@@ -17,8 +44,9 @@ class ManifestAppenderTransformer implements Transformer {
 
     List<Tuple2<String, ? extends Comparable<?>>> getAttributes() { attributes }
 
-    boolean attribute(String name, Comparable<?> value) {
+    ManifestAppenderTransformer append(String name, Comparable<?> value) {
         attributes.add(new Tuple2<String, ? extends Comparable<?>>(name, value))
+        this
     }
 
     @Override
@@ -28,8 +56,10 @@ class ManifestAppenderTransformer implements Transformer {
 
     @Override
     void transform(TransformerContext context) {
-        manifestContents = IOUtil.toByteArray(context.is)
-        IOUtil.close(context.is)
+        if (manifestContents.length == 0) {
+            manifestContents = IOUtil.toByteArray(context.is)
+            IOUtil.close(context.is)
+        }
     }
 
     @Override

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformerTest.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformerTest.groovy
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License") you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.github.jengelman.gradle.plugins.shadow.transformers
 
 import com.github.jengelman.gradle.plugins.shadow.ShadowStats
@@ -11,6 +30,9 @@ import java.util.zip.ZipFile
 import static java.util.Arrays.asList
 import static org.junit.Assert.*
 
+/**
+ * Test for {@link ManifestAppenderTransformer}.
+ */
 class ManifestAppenderTransformerTest extends TransformerTestSupport {
     static final String MANIFEST_NAME = "META-INF/MANIFEST.MF"
 
@@ -23,8 +45,10 @@ class ManifestAppenderTransformerTest extends TransformerTestSupport {
 
     @Test
     void testCanTransformResource() {
-        transformer.attribute('Name', 'org/foo/bar/')
-        transformer.attribute('Sealed', true)
+        transformer.with {
+            append('Name', 'org/foo/bar/')
+            append('Sealed', true)
+        }
 
         assertTrue(transformer.canTransformResource(getFileElement(MANIFEST_NAME)))
         assertTrue(transformer.canTransformResource(getFileElement(MANIFEST_NAME.toLowerCase())))
@@ -32,7 +56,7 @@ class ManifestAppenderTransformerTest extends TransformerTestSupport {
 
     @Test
     void testHasTransformedResource() {
-        transformer.attribute('Tag', 'Something')
+        transformer.append('Tag', 'Something')
 
         assertTrue(transformer.hasTransformedResource())
     }
@@ -44,12 +68,14 @@ class ManifestAppenderTransformerTest extends TransformerTestSupport {
 
     @Test
     void testTransformation() {
-        transformer.attribute('Name', 'org/foo/bar/')
-        transformer.attribute('Sealed', true)
-        transformer.attribute('Name', 'com/example/')
-        transformer.attribute('Sealed', false)
+        transformer.with {
+            append('Name', 'org/foo/bar/')
+            append('Sealed', true)
+            append('Name', 'com/example/')
+            append('Sealed', false)
 
-        transformer.transform(new TransformerContext(MANIFEST_NAME, getResourceStream(MANIFEST_NAME), Collections.<Relocator>emptyList(), new ShadowStats()))
+            transform(new TransformerContext(MANIFEST_NAME, getResourceStream(MANIFEST_NAME), Collections.<Relocator>emptyList(), new ShadowStats()))
+        }
 
         def testableZipFile = File.createTempFile("testable-zip-file-", ".jar")
         def fileOutputStream = new FileOutputStream(testableZipFile)

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformerTest.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformerTest.groovy
@@ -1,0 +1,122 @@
+package com.github.jengelman.gradle.plugins.shadow.transformers
+
+import com.github.jengelman.gradle.plugins.shadow.ShadowStats
+import com.github.jengelman.gradle.plugins.shadow.relocation.Relocator
+import org.apache.tools.zip.ZipOutputStream
+import org.junit.Before
+import org.junit.Test
+
+import java.util.zip.ZipFile
+
+import static java.util.Arrays.asList
+import static org.junit.Assert.*
+
+class ManifestAppenderTransformerTest extends TransformerTestSupport {
+    public static final String MANIFEST_FILE = "META-INF/MANIFEST.MF"
+
+    private ManifestAppenderTransformer transformer
+
+    @Before
+    void setUp() {
+        transformer = new ManifestAppenderTransformer()
+    }
+
+    @Test
+    void testCanTransformResource() {
+        transformer.attributes = [
+            new Tuple2( 'Name', 'org/foo/bar/' ),
+            new Tuple2( 'Sealed', true )
+        ]
+
+        assertTrue(transformer.canTransformResource(getFileElement(MANIFEST_FILE)))
+        assertTrue(transformer.canTransformResource(getFileElement(MANIFEST_FILE.toLowerCase())))
+    }
+
+    @Test
+    void testHasTransformedResource() {
+        transformer.attributes = [
+            new Tuple2( 'Tag', 'Something' )
+        ]
+
+        assertTrue(transformer.hasTransformedResource())
+    }
+
+    @Test
+    void testHasNotTransformedResource() {
+        assertFalse(transformer.hasTransformedResource())
+    }
+
+    @Test
+    void testTransformation() {
+        transformer.attributes = [
+            new Tuple2( 'Name', 'org/foo/bar/' ),
+            new Tuple2( 'Sealed', true ),
+            new Tuple2( 'Name', 'com/example/' ),
+            new Tuple2( 'Sealed', false )
+        ]
+
+        transformer.transform(new TransformerContext(MANIFEST_FILE, getResourceStream(MANIFEST_FILE), Collections.<Relocator>emptyList(), new ShadowStats()))
+
+        def testableZipFile = File.createTempFile("testable-zip-file-", ".jar")
+        def fileOutputStream = new FileOutputStream(testableZipFile)
+        def bufferedOutputStream = new BufferedOutputStream(fileOutputStream)
+        def zipOutputStream = new ZipOutputStream(bufferedOutputStream)
+
+        try {
+            transformer.modifyOutputStream(zipOutputStream, true)
+        } finally {
+            zipOutputStream.close()
+        }
+
+        def targetLines = readFrom(testableZipFile, MANIFEST_FILE)
+        assertFalse(targetLines.isEmpty())
+        assertTrue(targetLines.size() > 4)
+
+        def trailer = targetLines.subList(targetLines.size() - 5, targetLines.size())
+        assertEquals(asList(
+            "Name: org/foo/bar/",
+            "Sealed: true",
+            "Name: com/example/",
+            "Sealed: false",
+            ""), trailer
+        )
+    }
+
+    @Test
+    void testNoTransformation() {
+        def sourceLines = getResourceStream(MANIFEST_FILE).readLines()
+
+        transformer.transform(new TransformerContext(MANIFEST_FILE, getResourceStream(MANIFEST_FILE), Collections.<Relocator>emptyList(), new ShadowStats()))
+
+        def testableZipFile = File.createTempFile("testable-zip-file-", ".jar")
+        def fileOutputStream = new FileOutputStream(testableZipFile)
+        def bufferedOutputStream = new BufferedOutputStream(fileOutputStream)
+        def zipOutputStream = new ZipOutputStream(bufferedOutputStream)
+
+        try {
+            transformer.modifyOutputStream(zipOutputStream, true)
+        } finally {
+            zipOutputStream.close()
+        }
+        def targetLines = readFrom(testableZipFile, MANIFEST_FILE)
+
+        assertEquals(sourceLines, targetLines)
+    }
+
+    static List<String> readFrom(File jarFile, String resourceName) {
+        def zip = new ZipFile(jarFile)
+        try {
+            def entry = zip.getEntry(resourceName)
+            if (!entry) {
+                return Collections.<String>emptyList()
+            }
+            return zip.getInputStream(entry).readLines()
+        } finally {
+            zip.close()
+        }
+    }
+
+    InputStream getResourceStream(String resource) {
+        this.class.getClassLoader().getResourceAsStream(resource)
+    }
+}


### PR DESCRIPTION
Java's manifest attributes are implemented using a `HashMap`, which makes them useless when the attributes must be written in a particular order. E.g. for sealing packages in jars:
```
Name: com/example/
Sealed: true
```

Implement a `Transformer` which can append tags to a manifest while preserving their order.

~Note: This is a WIP - my transformer's current UI is based on Groovy's `Tuple2`. However, I'm sure that Groovy can support something better.~

The transformer's current API is:
```groovy
shadowJar {
    transform(ManifestAppenderTransformer) {
        append('Name', 'first/sealed/package/')
        append('Sealed', true)
        append('Name', 'second/sealed/package/')
        append('Sealed', true)
    }
}
```