### PR TITLE
Address "path may not be null or empty" issue in UnusedTracker

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/UnusedTracker.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/UnusedTracker.groovy
@@ -58,11 +58,13 @@ class UnusedTracker {
         apiDependencies.each { dep ->
             if (dep instanceof ProjectDependency) {
                 apiJars.addAll(getApiJarsFromProject(dep.dependencyProject))
-                apiJars.add(runtimeConfiguration.find { it.name.endsWith("${dep.name}.jar") } as File)
+                def jar = runtimeConfiguration.find { it.name.contains("${dep.name}") && it.name.endsWith(".jar") }
+                if (jar != null) apiJars.add(jar as File)
             } else if (dep instanceof SelfResolvingDependency) {
                 apiJars.addAll(dep.resolve())
             } else {
-                apiJars.add(runtimeConfiguration.find { it.name.startsWith("${dep.name}-") } as File)
+                def jar = runtimeConfiguration.find { it.name.startsWith("${dep.name}-") }
+                if (jar != null) apiJars.add(jar as File)
             }
         }
 


### PR DESCRIPTION
Adresses issue #425 by preventing `null` values being added to the list of `api` jars.

**Note**: this PR also relaxes the filter predicate from `it.name.endsWith("${dep.name}.jar")` to `it.name.contains("${dep.name}") && it.name.endsWith(".jar")`. Not sure, if this a) allows wrong jars to be included and if it b) helps @swankjesse's use-cases described here: https://github.com/johnrengelman/shadow/issues/425#issuecomment-473608758

This PR is effectively a _duplicate_ of #477 