### PR TITLE
Additional escapes for args processing

### DIFF
--- a/src/main/resources/com/github/jengelman/gradle/plugins/shadow/internal/unixStartScript.txt
+++ b/src/main/resources/com/github/jengelman/gradle/plugins/shadow/internal/unixStartScript.txt
@@ -156,7 +156,7 @@ fi
 
 # Escape application args
 save() {
-    for i do printf %s\\n "\$i" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/' \\\\/" ; done
+    for i do printf %s\\\\n "\$i" | sed "s/'/'\\\\\\\\''/g;1s/^/'/;\\\$s/\\\$/' \\\\\\\\/" ; done
     echo " "
 }
 APP_ARGS=\$(save "\$@")


### PR DESCRIPTION
Fixes issue #465

For reference, gradle produces the following, which shadow should match:
```
for i do printf %s\\n "$i" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/' \\\\/" ; done
```