### PR TITLE
Gradle 6.x support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.1'
-        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.7.5"
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.9.9"
         classpath "com.gradle.publish:plugin-publish-plugin:0.10.0"
         classpath 'org.ajoberstar:grgit:2.1.1'
         classpath 'org.ajoberstar:gradle-git-publish:0.3.3'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -4,21 +4,21 @@ dependencies {
     shadow gradleApi()
     shadow 'org.codehaus.groovy:groovy-backports-compat23:2.4.15'
 
-    compile 'org.jdom:jdom2:2.0.6'
-    compile 'org.ow2.asm:asm:7.0-beta'
-    compile 'org.ow2.asm:asm-commons:7.0-beta'
-    compile 'commons-io:commons-io:2.5'
-    compile 'org.apache.ant:ant:1.9.7'
-    compile 'org.codehaus.plexus:plexus-utils:3.0.24'
-    compile "org.apache.logging.log4j:log4j-core:2.11.0"
-    compile('org.vafer:jdependency:2.1.1') {
+    implementation 'org.jdom:jdom2:2.0.6'
+    implementation 'org.ow2.asm:asm:7.0-beta'
+    implementation 'org.ow2.asm:asm-commons:7.0-beta'
+    implementation 'commons-io:commons-io:2.5'
+    implementation 'org.apache.ant:ant:1.9.7'
+    implementation 'org.codehaus.plexus:plexus-utils:3.0.24'
+    implementation "org.apache.logging.log4j:log4j-core:2.11.0"
+    implementation('org.vafer:jdependency:2.1.1') {
         exclude group: 'org.ow2.asm'
     }
 
-    testCompile("org.spockframework:spock-core:1.0-groovy-2.4") {
+    testImplementation("org.spockframework:spock-core:1.0-groovy-2.4") {
         exclude module: 'groovy-all'
     }
-    testCompile 'xmlunit:xmlunit:1.3'
-    testCompile 'commons-lang:commons-lang:2.6'
-    testCompile 'com.google.guava:guava:17.0'
+    testImplementation 'xmlunit:xmlunit:1.3'
+    testImplementation 'commons-lang:commons-lang:2.6'
+    testImplementation 'com.google.guava:guava:17.0'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.java
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.java
@@ -40,7 +40,7 @@ public class ShadowJar extends Jar implements ShadowSpec {
 
     public ShadowJar() {
         super();
-        setDuplicatesStrategy(DuplicatesStrategy.INHERIT);
+        setDuplicatesStrategy(DuplicatesStrategy.INCLUDE); //shadow filters out files later. This was the default behavior in  Gradle < 6.x
         versionUtil = new GradleVersionUtil(getProject().getGradle().getGradleVersion());
         dependencyFilter = new DefaultDependencyFilter(getProject());
         dependencyFilterForMinimize = new MinimizeDependencyFilter(getProject());

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.java
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.java
@@ -10,6 +10,7 @@ import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransf
 import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.file.DuplicatesStrategy;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.file.FileResolver;
@@ -39,6 +40,7 @@ public class ShadowJar extends Jar implements ShadowSpec {
 
     public ShadowJar() {
         super();
+        setDuplicatesStrategy(DuplicatesStrategy.INHERIT);
         versionUtil = new GradleVersionUtil(getProject().getGradle().getGradleVersion());
         dependencyFilter = new DefaultDependencyFilter(getProject());
         dependencyFilterForMinimize = new MinimizeDependencyFilter(getProject());

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowPluginSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowPluginSpec.groovy
@@ -86,7 +86,7 @@ class ShadowPluginSpec extends PluginSpecification {
         assert output.exists()
 
         where:
-        version << ['5.0', '5.1', '5.2', '5.3', '5.4', '5.5']
+        version << ['5.0', '5.1', '5.2', '5.3', '5.4', '5.5', '5.6']
     }
 
     def 'Error in Gradle versions < 5.0'() {


### PR DESCRIPTION
Gradle 6 introduces:

* warnings around the usage of `compile` and `testCompile` configurations as they will be removed in 7.0
* Gradle [Fails on duplicates by default](https://github.com/gradle/gradle/pull/10143/files) starting on 6.x. Before the default `DuplicateStrategy` was `INHERIT` which is to inherit the strategy from the parent copy spec, if any,  or `DuplicatesStrategy.INCLUDE` if the copy spec has no parent.

Also upgraded the build-info-extractor plugin as current version is not Gradle 6.x compatible with the following error:

```
> org.gradle.api.publish.maven.internal.publication.MavenPublicationInternal.getPublishableFiles()Lorg/gradle/api/file/FileCollection;
``` 