### PR TITLE
Make shadowJar task cacheable

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/UnusedTracker.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/UnusedTracker.groovy
@@ -6,6 +6,7 @@ import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.SelfResolvingDependency
 import org.gradle.api.file.FileCollection
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.SourceSet
 import org.vafer.jdependency.Clazz
 import org.vafer.jdependency.Clazzpath
@@ -48,6 +49,11 @@ class UnusedTracker {
             classDirs.addAll(classesDirs.findAll { it.isDirectory() })
         }
         return new UnusedTracker(classDirs, apiJars, toMinimize)
+    }
+
+    @InputFiles
+    FileCollection getToMinimize() {
+        return toMinimize
     }
 
     private static boolean isProjectDependencyFile(File file, Dependency dep) {

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/relocation/CacheableRelocator.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/relocation/CacheableRelocator.groovy
@@ -1,0 +1,17 @@
+package com.github.jengelman.gradle.plugins.shadow.relocation
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+/**
+ * Marks that a given instance of {@link Relocator} is is compatible with the Gradle build cache.
+ * In other words, it has its appropriate inputs annotated so that Gradle can consider them when
+ * determining the cache key.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@interface CacheableRelocator {
+
+}

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocator.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocator.groovy
@@ -31,27 +31,21 @@ import java.util.regex.Pattern
  * @author Mauro Talevi
  * @author John Engelman
  */
+@CacheableRelocator
 class SimpleRelocator implements Relocator {
 
-    @Input
     private final String pattern
 
-    @Input
     private final String pathPattern
 
-    @Input
     private final String shadedPattern
 
-    @Input
     private final String shadedPathPattern
 
-    @Input
     private final Set<String> includes
 
-    @Input
     private final Set<String> excludes
-
-    @Input
+    
     private final boolean rawString
 
     SimpleRelocator() {

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocator.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocator.groovy
@@ -20,6 +20,7 @@
 package com.github.jengelman.gradle.plugins.shadow.relocation
 
 import org.codehaus.plexus.util.SelectorUtils
+import org.gradle.api.tasks.Input
 
 import java.util.regex.Pattern
 
@@ -32,18 +33,25 @@ import java.util.regex.Pattern
  */
 class SimpleRelocator implements Relocator {
 
+    @Input
     private final String pattern
 
+    @Input
     private final String pathPattern
 
+    @Input
     private final String shadedPattern
 
+    @Input
     private final String shadedPathPattern
 
+    @Input
     private final Set<String> includes
 
+    @Input
     private final Set<String> excludes
 
+    @Input
     private final boolean rawString
 
     SimpleRelocator() {
@@ -187,5 +195,40 @@ class SimpleRelocator implements Relocator {
         } else {
             return sourceContent.replaceAll("\\b" + pattern, shadedPattern)
         }
+    }
+
+    @Input
+    String getPattern() {
+        return pattern
+    }
+
+    @Input
+    String getPathPattern() {
+        return pathPattern
+    }
+
+    @Input
+    String getShadedPattern() {
+        return shadedPattern
+    }
+
+    @Input
+    String getShadedPathPattern() {
+        return shadedPathPattern
+    }
+
+    @Input
+    Set<String> getIncludes() {
+        return includes
+    }
+
+    @Input
+    Set<String> getExcludes() {
+        return excludes
+    }
+
+    @Input
+    boolean getRawString() {
+        return rawString
     }
 }

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.java
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.java
@@ -14,12 +14,7 @@ import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.copy.CopyAction;
 import org.gradle.api.specs.Spec;
-import org.gradle.api.tasks.CacheableTask;
-import org.gradle.api.tasks.InputFiles;
-import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Nested;
-import org.gradle.api.tasks.Optional;
-import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.*;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.util.PatternSet;
 
@@ -119,7 +114,7 @@ public class ShadowJar extends Jar implements ShadowSpec {
         getLogger().info(shadowStats.toString());
     }
 
-    @InputFiles
+    @Classpath
     public FileCollection getIncludedDependencies() {
         return getProject().files(new Callable<FileCollection>() {
 
@@ -369,7 +364,7 @@ public class ShadowJar extends Jar implements ShadowSpec {
         this.relocators = relocators;
     }
 
-    @InputFiles @Optional
+    @Classpath @Optional
     public List<Configuration> getConfigurations() {
         return this.configurations;
     }

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformer.groovy
@@ -23,6 +23,7 @@ import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
 import org.codehaus.plexus.util.IOUtil
 import org.gradle.api.file.FileTreeElement
+import org.gradle.api.tasks.Input
 
 /**
  * A resource processor that appends content for a resource, separated by a newline.
@@ -64,5 +65,10 @@ class AppendingTransformer implements Transformer {
 
         IOUtil.copy(new ByteArrayInputStream(data.toByteArray()), os)
         data.reset()
+    }
+
+    @Input
+    String getResource() {
+        return resource
     }
 }

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformer.groovy
@@ -33,6 +33,7 @@ import org.gradle.api.tasks.Input
  * Modifications
  * @author John Engelman
  */
+@CacheableTransformer
 class AppendingTransformer implements Transformer {
     String resource
 

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/CacheableTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/CacheableTransformer.groovy
@@ -1,0 +1,17 @@
+package com.github.jengelman.gradle.plugins.shadow.transformers
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+/**
+ * Marks that a given instance of {@link Transformer} is is compatible with the Gradle build cache.
+ * In other words, it has its appropriate inputs annotated so that Gradle can consider them when
+ * determining the cache key.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@interface CacheableTransformer {
+
+}

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/GroovyExtensionModuleTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/GroovyExtensionModuleTransformer.groovy
@@ -32,6 +32,7 @@ import org.codehaus.plexus.util.IOUtil
  * entries will all be merged into a single META-INF/services/org.codehaus.groovy.runtime.ExtensionModule resource
  * packaged into the resultant JAR produced by the shadowing process.
  */
+@CacheableTransformer
 class GroovyExtensionModuleTransformer implements Transformer {
 
     private static final GROOVY_EXTENSION_MODULE_DESCRIPTOR_PATH =

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.groovy
@@ -43,6 +43,7 @@ import org.codehaus.plexus.util.IOUtil
  * @author Charlie Knudsen
  * @author John Engelman
  */
+@CacheableTransformer
 class ServiceFileTransformer implements Transformer, PatternFilterable {
 
     private static final String SERVICES_PATTERN = "META-INF/services/**"

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.groovy
@@ -25,6 +25,7 @@ import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
 import org.gradle.api.file.FileTreeElement
 import org.gradle.api.specs.Spec
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.util.PatternFilterable
 import org.gradle.api.tasks.util.PatternSet
 import org.codehaus.plexus.util.IOUtil
@@ -193,6 +194,7 @@ class ServiceFileTransformer implements Transformer, PatternFilterable {
      * {@inheritDoc}
      */
     @Override
+    @Input
     Set<String> getIncludes() {
         return patternSet.includes
     }
@@ -210,6 +212,7 @@ class ServiceFileTransformer implements Transformer, PatternFilterable {
      * {@inheritDoc}
      */
     @Override
+    @Input
     Set<String> getExcludes() {
         return patternSet.excludes
     }
@@ -222,5 +225,4 @@ class ServiceFileTransformer implements Transformer, PatternFilterable {
         patternSet.excludes = excludes
         return this
     }
-
 }

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/XmlAppendingTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/XmlAppendingTransformer.groovy
@@ -22,6 +22,7 @@ package com.github.jengelman.gradle.plugins.shadow.transformers
 import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
 import org.gradle.api.file.FileTreeElement
+import org.gradle.api.tasks.Input
 import org.jdom2.Attribute
 import org.jdom2.Content
 import org.jdom2.Document
@@ -109,5 +110,10 @@ class XmlAppendingTransformer implements Transformer {
         new XMLOutputter(Format.getPrettyFormat()).output(doc, os)
 
         doc = null
+    }
+
+    @Input
+    String getResource() {
+        return resource
     }
 }

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/XmlAppendingTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/XmlAppendingTransformer.groovy
@@ -42,6 +42,7 @@ import org.xml.sax.SAXException
  *
  * @author John Engelman
  */
+@CacheableTransformer
 class XmlAppendingTransformer implements Transformer {
     static final String XSI_NS = "http://www.w3.org/2001/XMLSchema-instance"
 

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/AbstractCachingSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/AbstractCachingSpec.groovy
@@ -56,13 +56,13 @@ class AbstractCachingSpec extends PluginSpecification {
     }
 
     void assertShadowJarHasResult(TaskOutcome expectedOutcome) {
-        def result = runWithCacheEnabled("shadowJar")
-        assert result.task(':shadowJar').outcome == expectedOutcome
+        def result = runWithCacheEnabled(shadowJarTask)
+        assert result.task(shadowJarTask).outcome == expectedOutcome
     }
 
     void assertShadowJarHasResultInAlternateDir(TaskOutcome expectedOutcome) {
-        def result = runInAlternateDirWithCacheEnabled("shadowJar")
-        assert result.task(':shadowJar').outcome == expectedOutcome
+        def result = runInAlternateDirWithCacheEnabled(shadowJarTask)
+        assert result.task(shadowJarTask).outcome == expectedOutcome
     }
 
     void copyToAlternateDir() {
@@ -90,5 +90,9 @@ class AbstractCachingSpec extends PluginSpecification {
         if (output.exists()) {
             assert output.delete()
         }
+    }
+
+    String getShadowJarTask() {
+        return ":shadowJar"
     }
 }

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/AbstractCachingSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/AbstractCachingSpec.groovy
@@ -1,11 +1,20 @@
 package com.github.jengelman.gradle.plugins.shadow.caching
 
 import com.github.jengelman.gradle.plugins.shadow.util.PluginSpecification
+import org.apache.commons.io.FileUtils
 import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+
+import static org.gradle.testkit.runner.TaskOutcome.FROM_CACHE
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 
 class AbstractCachingSpec extends PluginSpecification {
+    @Rule TemporaryFolder alternateDir
+
     def setup() {
         // Use a test-specific build cache directory.  This ensures that we'll only use cached outputs generated during this
         // test and we won't accidentally use cached outputs from a different test or a different build.
@@ -29,23 +38,52 @@ class AbstractCachingSpec extends PluginSpecification {
         return runner.withArguments(cacheArguments).build()
     }
 
+    BuildResult runInAlternateDirWithCacheEnabled(String... arguments) {
+        List<String> cacheArguments = [ '--build-cache' ]
+        cacheArguments.addAll(arguments)
+        return alternateDirRunner.withArguments(cacheArguments).build()
+    }
+
+    GradleRunner getAlternateDirRunner() {
+        GradleRunner.create()
+                .withProjectDir(alternateDir.root)
+                .forwardOutput()
+                .withPluginClasspath()
+    }
+
     private String escapedPath(File file) {
         file.path.replaceAll('\\\\', '\\\\\\\\')
     }
 
-    void assertShadowJarResult(TaskOutcome expectedOutcome) {
+    void assertShadowJarHasResult(TaskOutcome expectedOutcome) {
         def result = runWithCacheEnabled("shadowJar")
         assert result.task(':shadowJar').outcome == expectedOutcome
     }
 
-    void assertShadowJarCached() {
-        deleteOutputs()
-        assertShadowJarResult(TaskOutcome.FROM_CACHE)
+    void assertShadowJarHasResultInAlternateDir(TaskOutcome expectedOutcome) {
+        def result = runInAlternateDirWithCacheEnabled("shadowJar")
+        assert result.task(':shadowJar').outcome == expectedOutcome
     }
 
-    void assertShadowJarNotCached() {
+    void copyToAlternateDir() {
+        FileUtils.deleteDirectory(alternateDir.root)
+        FileUtils.forceMkdir(alternateDir.root)
+        FileUtils.copyDirectory(dir.root, alternateDir.root)
+    }
+
+    void assertShadowJarIsCachedAndRelocatable() {
         deleteOutputs()
-        assertShadowJarResult(TaskOutcome.SUCCESS)
+        copyToAlternateDir()
+        // check that shadowJar pulls from cache in the original directory
+        assertShadowJarHasResult(FROM_CACHE)
+        // check that shadowJar pulls from cache in a different directory
+        assertShadowJarHasResultInAlternateDir(FROM_CACHE)
+    }
+
+    void assertShadowJarExecutes() {
+        deleteOutputs()
+        // task was executed and not pulled from cache
+        assertShadowJarHasResult(SUCCESS)
     }
 
     void deleteOutputs() {

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/AbstractCachingSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/AbstractCachingSpec.groovy
@@ -1,0 +1,56 @@
+package com.github.jengelman.gradle.plugins.shadow.caching
+
+import com.github.jengelman.gradle.plugins.shadow.util.PluginSpecification
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.TaskOutcome
+
+
+class AbstractCachingSpec extends PluginSpecification {
+    def setup() {
+        // Use a test-specific build cache directory.  This ensures that we'll only use cached outputs generated during this
+        // test and we won't accidentally use cached outputs from a different test or a different build.
+        settingsFile << """
+            buildCache {
+                local(DirectoryBuildCache) {
+                    directory = new File(rootDir, 'build-cache')
+                }
+            }
+        """
+    }
+
+    void changeConfigurationTo(String content) {
+        buildFile.text = defaultBuildScript
+        buildFile << content
+    }
+
+    BuildResult runWithCacheEnabled(String... arguments) {
+        List<String> cacheArguments = [ '--build-cache' ]
+        cacheArguments.addAll(arguments)
+        return runner.withArguments(cacheArguments).build()
+    }
+
+    private String escapedPath(File file) {
+        file.path.replaceAll('\\\\', '\\\\\\\\')
+    }
+
+    void assertShadowJarResult(TaskOutcome expectedOutcome) {
+        def result = runWithCacheEnabled("shadowJar")
+        assert result.task(':shadowJar').outcome == expectedOutcome
+    }
+
+    void assertShadowJarCached() {
+        deleteOutputs()
+        assertShadowJarResult(TaskOutcome.FROM_CACHE)
+    }
+
+    void assertShadowJarNotCached() {
+        deleteOutputs()
+        assertShadowJarResult(TaskOutcome.SUCCESS)
+    }
+
+    void deleteOutputs() {
+        if (output.exists()) {
+            assert output.delete()
+        }
+    }
+}

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/MinimizationCachingSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/MinimizationCachingSpec.groovy
@@ -1,0 +1,100 @@
+package com.github.jengelman.gradle.plugins.shadow.caching
+
+import org.gradle.testkit.runner.BuildResult
+
+import static org.gradle.testkit.runner.TaskOutcome.*
+
+class MinimizationCachingSpec extends AbstractCachingSpec {
+    /**
+     * Ensure that we get a cache miss when minimization is added and that caching works with minimization
+     */
+    def 'shadowJar is cached correctly when minimization is added'() {
+        given:
+        file('settings.gradle') << """
+            include 'client', 'server'
+        """.stripIndent()
+
+        file('client/src/main/java/client/Client.java') << """
+            package client;
+            public class Client {}
+        """.stripIndent()
+
+        file('client/build.gradle') << """
+            apply plugin: 'java'
+            repositories { maven { url "${repo.uri}" } }
+            dependencies { compile 'junit:junit:3.8.2' }
+        """.stripIndent()
+
+        file('server/src/main/java/server/Server.java') << """
+            package server;
+            public class Server {}
+        """.stripIndent()
+
+        file('server/build.gradle') << """
+            apply plugin: 'java'
+            apply plugin: 'com.github.johnrengelman.shadow'
+
+            repositories { maven { url "${repo.uri}" } }
+            dependencies { compile project(':client') }
+        """.stripIndent()
+
+        File serverOutput = getFile('server/build/libs/server-all.jar')
+
+        when:
+        BuildResult result = runWithCacheEnabled(':server:shadowJar')
+
+        then:
+        serverOutput.exists()
+        contains(serverOutput, [
+                'server/Server.class',
+                'junit/framework/Test.class',
+                'client/Client.class'
+        ])
+
+        and:
+        result.task(':server:shadowJar').outcome == SUCCESS
+
+        when:
+        serverOutput.delete()
+        file('server/build.gradle').text = """
+            apply plugin: 'java'
+            apply plugin: 'com.github.johnrengelman.shadow'
+
+            shadowJar {
+                minimize {
+                    exclude(dependency('junit:junit:.*'))
+                }
+            }
+
+            repositories { maven { url "${repo.uri}" } }
+            dependencies { compile project(':client') }
+        """.stripIndent()
+        runWithCacheEnabled(':server:shadowJar')
+
+        then:
+        serverOutput.exists()
+        contains(serverOutput, [
+                'server/Server.class',
+                'junit/framework/Test.class'
+        ])
+        doesNotContain(serverOutput, ['client/Client.class'])
+
+        and:
+        result.task(':server:shadowJar').outcome == SUCCESS
+
+        when:
+        serverOutput.delete()
+        result = runWithCacheEnabled(':server:shadowJar')
+
+        then:
+        serverOutput.exists()
+        contains(serverOutput, [
+                'server/Server.class',
+                'junit/framework/Test.class'
+        ])
+        doesNotContain(serverOutput, ['client/Client.class'])
+
+        and:
+        result.task(':server:shadowJar').outcome == FROM_CACHE
+    }
+}

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/RelocationCachingSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/RelocationCachingSpec.groovy
@@ -1,9 +1,5 @@
 package com.github.jengelman.gradle.plugins.shadow.caching
 
-import org.gradle.testkit.runner.BuildResult
-
-import static org.gradle.testkit.runner.TaskOutcome.*
-
 class RelocationCachingSpec extends AbstractCachingSpec {
     /**
      * Ensure that we get a cache miss when relocation changes and that caching works with relocation
@@ -23,7 +19,7 @@ class RelocationCachingSpec extends AbstractCachingSpec {
         """.stripIndent()
 
         when:
-        assertShadowJarNotCached()
+        assertShadowJarExecutes()
 
         then:
         output.exists()
@@ -40,7 +36,7 @@ class RelocationCachingSpec extends AbstractCachingSpec {
                relocate 'junit.framework', 'foo.junit.framework'
             }
         """
-        assertShadowJarNotCached()
+        assertShadowJarExecutes()
 
         then:
         output.exists()
@@ -55,7 +51,7 @@ class RelocationCachingSpec extends AbstractCachingSpec {
         ])
 
         when:
-        assertShadowJarCached()
+        assertShadowJarIsCachedAndRelocatable()
 
         then:
         output.exists()

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/RelocationCachingSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/RelocationCachingSpec.groovy
@@ -1,0 +1,72 @@
+package com.github.jengelman.gradle.plugins.shadow.caching
+
+import org.gradle.testkit.runner.BuildResult
+
+import static org.gradle.testkit.runner.TaskOutcome.*
+
+class RelocationCachingSpec extends AbstractCachingSpec {
+    /**
+     * Ensure that we get a cache miss when relocation changes and that caching works with relocation
+     */
+    def 'shadowJar is cached correctly when relocation is added'() {
+        given:
+        buildFile << """
+            dependencies { compile 'junit:junit:3.8.2' }
+        """.stripIndent()
+
+        file('src/main/java/server/Server.java') << """
+            package server;
+
+            import junit.framework.Test;
+
+            public class Server {}
+        """.stripIndent()
+
+        when:
+        assertShadowJarNotCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class',
+                'junit/framework/Test.class'
+        ])
+
+        when:
+        changeConfigurationTo """
+            dependencies { compile 'junit:junit:3.8.2' }
+
+            shadowJar {
+               relocate 'junit.framework', 'foo.junit.framework'
+            }
+        """
+        assertShadowJarNotCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class',
+                'foo/junit/framework/Test.class'
+        ])
+
+        and:
+        doesNotContain(output, [
+                'junit/framework/Test.class'
+        ])
+
+        when:
+        assertShadowJarCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class',
+                'foo/junit/framework/Test.class'
+        ])
+
+        and:
+        doesNotContain(output, [
+                'junit/framework/Test.class'
+        ])
+    }
+}

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/ShadowJarCachingSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/ShadowJarCachingSpec.groovy
@@ -1,17 +1,5 @@
 package com.github.jengelman.gradle.plugins.shadow.caching
 
-import com.github.jengelman.gradle.plugins.shadow.transformers.AppendingTransformer
-import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer
-import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer
-import com.github.jengelman.gradle.plugins.shadow.transformers.TransformerContext
-import com.github.jengelman.gradle.plugins.shadow.util.PluginSpecification
-import org.apache.tools.zip.ZipOutputStream
-import org.gradle.api.file.FileTreeElement
-import org.gradle.testkit.runner.BuildResult
-import spock.lang.Unroll
-
-import static org.gradle.testkit.runner.TaskOutcome.*
-
 class ShadowJarCachingSpec extends AbstractCachingSpec {
 
     /**
@@ -30,13 +18,13 @@ class ShadowJarCachingSpec extends AbstractCachingSpec {
         """.stripIndent()
 
         when:
-        assertShadowJarNotCached()
+        assertShadowJarExecutes()
 
         then:
         assert output.exists()
 
         when:
-        assertShadowJarCached()
+        assertShadowJarIsCachedAndRelocatable()
 
         then:
         assert output.exists()
@@ -47,7 +35,7 @@ class ShadowJarCachingSpec extends AbstractCachingSpec {
                 from('${artifact.path}')
             }
         """
-        assertShadowJarNotCached()
+        assertShadowJarExecutes()
 
         then:
         assert output.exists()
@@ -69,7 +57,7 @@ class ShadowJarCachingSpec extends AbstractCachingSpec {
         """.stripIndent()
 
         when:
-        assertShadowJarNotCached()
+        assertShadowJarExecutes()
 
         then:
         assert output.exists()
@@ -82,7 +70,7 @@ class ShadowJarCachingSpec extends AbstractCachingSpec {
                 from('${project.path}')
             }
         """
-        assertShadowJarCached()
+        assertShadowJarIsCachedAndRelocatable()
 
         then:
         assert !output.exists()
@@ -119,7 +107,7 @@ class ShadowJarCachingSpec extends AbstractCachingSpec {
         """.stripIndent()
 
         when:
-        assertShadowJarNotCached()
+        assertShadowJarExecutes()
 
         then:
         output.exists()
@@ -137,7 +125,7 @@ class ShadowJarCachingSpec extends AbstractCachingSpec {
                exclude '*/Util.*'
             }
         """
-        assertShadowJarNotCached()
+        assertShadowJarExecutes()
 
         then:
         output.exists()
@@ -152,7 +140,7 @@ class ShadowJarCachingSpec extends AbstractCachingSpec {
         ])
 
         when:
-        assertShadowJarCached()
+        assertShadowJarIsCachedAndRelocatable()
 
         then:
         output.exists()
@@ -185,7 +173,7 @@ class ShadowJarCachingSpec extends AbstractCachingSpec {
         """.stripIndent()
 
         when:
-        assertShadowJarNotCached()
+        assertShadowJarExecutes()
 
         then:
         output.exists()
@@ -204,7 +192,7 @@ class ShadowJarCachingSpec extends AbstractCachingSpec {
                }
             }
         """
-        assertShadowJarNotCached()
+        assertShadowJarExecutes()
 
         then:
         output.exists()
@@ -218,7 +206,7 @@ class ShadowJarCachingSpec extends AbstractCachingSpec {
         ])
 
         when:
-        assertShadowJarCached()
+        assertShadowJarIsCachedAndRelocatable()
 
         then:
         output.exists()

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/ShadowJarCachingSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/ShadowJarCachingSpec.groovy
@@ -1,0 +1,234 @@
+package com.github.jengelman.gradle.plugins.shadow.caching
+
+import com.github.jengelman.gradle.plugins.shadow.transformers.AppendingTransformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.TransformerContext
+import com.github.jengelman.gradle.plugins.shadow.util.PluginSpecification
+import org.apache.tools.zip.ZipOutputStream
+import org.gradle.api.file.FileTreeElement
+import org.gradle.testkit.runner.BuildResult
+import spock.lang.Unroll
+
+import static org.gradle.testkit.runner.TaskOutcome.*
+
+class ShadowJarCachingSpec extends AbstractCachingSpec {
+
+    /**
+     * Ensure that a basic usage reuses an output from cache and then gets a cache miss when the content changes.
+     */
+    def "shadowJar is cached correctly when copying"() {
+        given:
+        URL artifact = this.class.classLoader.getResource('test-artifact-1.0-SNAPSHOT.jar')
+        URL project = this.class.classLoader.getResource('test-project-1.0-SNAPSHOT.jar')
+
+        buildFile << """
+            shadowJar {
+                from('${artifact.path}')
+                from('${project.path}')
+            }
+        """.stripIndent()
+
+        when:
+        assertShadowJarNotCached()
+
+        then:
+        assert output.exists()
+
+        when:
+        assertShadowJarCached()
+
+        then:
+        assert output.exists()
+
+        when:
+        changeConfigurationTo """
+            shadowJar {
+                from('${artifact.path}')
+            }
+        """
+        assertShadowJarNotCached()
+
+        then:
+        assert output.exists()
+    }
+
+    /**
+     * Ensure that an output is reused from the cache if only the output file name is changed.
+     */
+    def "shadowJar is cached correctly when output file is changed"() {
+        given:
+        URL artifact = this.class.classLoader.getResource('test-artifact-1.0-SNAPSHOT.jar')
+        URL project = this.class.classLoader.getResource('test-project-1.0-SNAPSHOT.jar')
+
+        buildFile << """
+            shadowJar {
+                from('${artifact.path}')
+                from('${project.path}')
+            }
+        """.stripIndent()
+
+        when:
+        assertShadowJarNotCached()
+
+        then:
+        assert output.exists()
+
+        when:
+        changeConfigurationTo """
+            shadowJar {
+                baseName = "foo"
+                from('${artifact.path}')
+                from('${project.path}')
+            }
+        """
+        assertShadowJarCached()
+
+        then:
+        assert !output.exists()
+        assert getFile("build/libs/foo-1.0-all.jar").exists()
+    }
+
+    /**
+     * Ensure that we get a cache miss when includes/excludes change and that caching works when includes/excludes are present
+     */
+    def 'shadowJar is cached correctly when using includes/excludes'() {
+        given:
+        buildFile << """
+            dependencies { compile 'junit:junit:3.8.2' }
+            
+            shadowJar {
+                exclude 'junit/*'
+            }
+        """.stripIndent()
+
+        file('src/main/java/server/Server.java') << """
+            package server;
+
+            import junit.framework.Test;
+
+            public class Server {}
+        """.stripIndent()
+
+        file('src/main/java/server/Util.java') << """
+            package server;
+
+            import junit.framework.Test;
+
+            public class Util {}
+        """.stripIndent()
+
+        when:
+        assertShadowJarNotCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class',
+                'server/Util.class'
+        ])
+
+        when:
+        changeConfigurationTo """
+            dependencies { compile 'junit:junit:3.8.2' }
+
+            shadowJar {
+               include 'server/*'
+               exclude '*/Util.*'
+            }
+        """
+        assertShadowJarNotCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class'
+        ])
+
+        and:
+        doesNotContain(output, [
+                'server/Util.class',
+                'junit/framework/Test.class'
+        ])
+
+        when:
+        assertShadowJarCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class'
+        ])
+
+        and:
+        doesNotContain(output, [
+                'server/Util.class',
+                'junit/framework/Test.class'
+        ])
+    }
+
+    /**
+     * Ensure that we get a cache miss when dependency includes/excludes are added and caching works when dependency includes/excludes are present
+     */
+    def 'shadowJar is cached correctly when using dependency includes/excludes'() {
+        given:
+        buildFile << """
+            dependencies { compile 'junit:junit:3.8.2' }
+        """.stripIndent()
+
+        file('src/main/java/server/Server.java') << """
+            package server;
+
+            import junit.framework.Test;
+
+            public class Server {}
+        """.stripIndent()
+
+        when:
+        assertShadowJarNotCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class',
+                'junit/framework/Test.class'
+        ])
+
+        when:
+        changeConfigurationTo """
+            dependencies { compile 'junit:junit:3.8.2' }
+
+            shadowJar {
+               dependencies {
+                    exclude(dependency('junit:junit'))
+               }
+            }
+        """
+        assertShadowJarNotCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class'
+        ])
+
+        and:
+        doesNotContain(output, [
+                'junit/framework/Test.class'
+        ])
+
+        when:
+        assertShadowJarCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class'
+        ])
+
+        and:
+        doesNotContain(output, [
+                'junit/framework/Test.class'
+        ])
+    }
+}

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/TransformCachingSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/TransformCachingSpec.groovy
@@ -1,0 +1,358 @@
+package com.github.jengelman.gradle.plugins.shadow.caching
+
+import com.github.jengelman.gradle.plugins.shadow.transformers.AppendingTransformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.GroovyExtensionModuleTransformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.XmlAppendingTransformer
+import org.gradle.testkit.runner.BuildResult
+import spock.lang.Unroll
+
+import static org.gradle.testkit.runner.TaskOutcome.*
+
+
+class TransformCachingSpec extends AbstractCachingSpec {
+    /**
+     * Ensure that that caching is disabled when transforms are used
+     */
+    def 'shadowJar is not cached when custom transforms are used'() {
+        given:
+        file('src/main/java/server/Server.java') << """
+            package server;
+
+            public class Server {}
+        """.stripIndent()
+
+        buildFile << """
+            import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer
+            import com.github.jengelman.gradle.plugins.shadow.transformers.TransformerContext
+            import org.apache.tools.zip.ZipOutputStream
+            import org.gradle.api.file.FileTreeElement
+            
+            class CustomTransformer implements Transformer {
+                @Override
+                boolean canTransformResource(FileTreeElement element) {
+                    return false
+                }
+        
+                @Override
+                void transform(TransformerContext context) {
+        
+                }
+        
+                @Override
+                boolean hasTransformedResource() {
+                    return false
+                }
+        
+                @Override
+                void modifyOutputStream(ZipOutputStream jos, boolean preserveFileTimestamps) {
+        
+                }
+            }
+
+            shadowJar {
+                transform(CustomTransformer)
+            }
+        """.stripIndent()
+
+        when:
+        assertShadowJarNotCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class'
+        ])
+
+        when:
+        assertShadowJarNotCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class'
+        ])
+    }
+
+    /**
+     * Ensure that we get a cache miss when ServiceFileTransformer transforms are added and caching works when ServiceFileTransformer transforms are present
+     */
+    @Unroll
+    def 'shadowJar is cached correctly when using ServiceFileTransformer'() {
+        given:
+        file('src/main/java/server/Server.java') << """
+            package server;
+
+            public class Server {}
+        """.stripIndent()
+
+        when:
+        assertShadowJarNotCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class'
+        ])
+
+        when:
+        // Add a transform
+        changeConfigurationTo """
+            shadowJar {
+               transform(${ServiceFileTransformer.name}) {
+                    path = 'META-INF/foo'
+               }
+            }
+        """
+        assertShadowJarNotCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class'
+        ])
+
+        when:
+        assertShadowJarCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class'
+        ])
+
+        when:
+        // Change the transform configuration
+        changeConfigurationTo """
+            shadowJar {
+               transform(${ServiceFileTransformer.name}) {
+                    path = 'META-INF/bar'
+               }
+            }
+        """
+        assertShadowJarNotCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class'
+        ])
+
+        when:
+        assertShadowJarCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class'
+        ])
+    }
+
+    /**
+     * Ensure that we get a cache miss when AppendingTransformer transforms are added and caching works when AppendingTransformer transforms are present
+     */
+    @Unroll
+    def 'shadowJar is cached correctly when using AppendingTransformer'() {
+        given:
+        file('src/main/resources/foo/bar.properties') << "foo=bar"
+        file('src/main/java/server/Server.java') << """
+            package server;
+
+            public class Server {}
+        """.stripIndent()
+
+        when:
+        assertShadowJarNotCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class'
+        ])
+
+        when:
+        // Add a transform
+        changeConfigurationTo """
+            shadowJar {
+               transform(${AppendingTransformer.name}) {
+                    resource = 'foo/bar.properties'
+               }
+            }
+        """
+        assertShadowJarNotCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class',
+                'foo/bar.properties'
+        ])
+
+        when:
+        assertShadowJarCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class',
+                'foo/bar.properties'
+        ])
+
+        when:
+        // Change the transform configuration
+        assert file('src/main/resources/foo/bar.properties').delete()
+        file('src/main/resources/foo/baz.properties') << "foo=baz"
+        changeConfigurationTo """
+            shadowJar {
+               transform(${AppendingTransformer.name}) {
+                    resource = 'foo/baz.properties'
+               }
+            }
+        """
+        assertShadowJarNotCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class',
+                'foo/baz.properties'
+        ])
+
+        when:
+        assertShadowJarCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class',
+                'foo/baz.properties'
+        ])
+    }
+
+    /**
+     * Ensure that we get a cache miss when XmlAppendingTransformer transforms are added and caching works when XmlAppendingTransformer transforms are present
+     */
+    @Unroll
+    def 'shadowJar is cached correctly when using XmlAppendingTransformer'() {
+        given:
+        file('src/main/resources/foo/bar.xml') << "<foo>bar</foo>"
+        file('src/main/java/server/Server.java') << """
+            package server;
+
+            public class Server {}
+        """.stripIndent()
+
+        when:
+        assertShadowJarNotCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class'
+        ])
+
+        when:
+        // Add a transform
+        changeConfigurationTo """
+            shadowJar {
+               transform(${XmlAppendingTransformer.name}) {
+                    resource = 'foo/bar.xml'
+               }
+            }
+        """
+        assertShadowJarNotCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class',
+                'foo/bar.xml'
+        ])
+
+        when:
+        assertShadowJarCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class',
+                'foo/bar.xml'
+        ])
+
+        when:
+        // Change the transform configuration
+        assert file('src/main/resources/foo/bar.xml').delete()
+        file('src/main/resources/foo/baz.xml') << "<foo>baz</foo>"
+        changeConfigurationTo """
+            shadowJar {
+               transform(${AppendingTransformer.name}) {
+                    resource = 'foo/baz.xml'
+               }
+            }
+        """
+        assertShadowJarNotCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class',
+                'foo/baz.xml'
+        ])
+
+        when:
+        assertShadowJarCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class',
+                'foo/baz.xml'
+        ])
+    }
+
+    /**
+     * Ensure that we get a cache miss when GroovyExtensionModuleTransformer transforms are added and caching works when GroovyExtensionModuleTransformer transforms are present
+     */
+    @Unroll
+    def 'shadowJar is cached correctly when using GroovyExtensionModuleTransformer'() {
+        given:
+        file('src/main/java/server/Server.java') << """
+            package server;
+
+            public class Server {}
+        """.stripIndent()
+
+        when:
+        assertShadowJarNotCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class'
+        ])
+
+        when:
+        // Add a transform
+        changeConfigurationTo """
+            shadowJar {
+               transform(${GroovyExtensionModuleTransformer.name})
+            }
+        """
+        assertShadowJarNotCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class'
+        ])
+
+        when:
+        assertShadowJarCached()
+
+        then:
+        output.exists()
+        contains(output, [
+                'server/Server.class'
+        ])
+    }
+}

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/TransformCachingSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/TransformCachingSpec.groovy
@@ -4,11 +4,7 @@ import com.github.jengelman.gradle.plugins.shadow.transformers.AppendingTransfor
 import com.github.jengelman.gradle.plugins.shadow.transformers.GroovyExtensionModuleTransformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.XmlAppendingTransformer
-import org.gradle.testkit.runner.BuildResult
 import spock.lang.Unroll
-
-import static org.gradle.testkit.runner.TaskOutcome.*
-
 
 class TransformCachingSpec extends AbstractCachingSpec {
     /**
@@ -56,7 +52,7 @@ class TransformCachingSpec extends AbstractCachingSpec {
         """.stripIndent()
 
         when:
-        assertShadowJarNotCached()
+        assertShadowJarExecutes()
 
         then:
         output.exists()
@@ -65,7 +61,7 @@ class TransformCachingSpec extends AbstractCachingSpec {
         ])
 
         when:
-        assertShadowJarNotCached()
+        assertShadowJarExecutes()
 
         then:
         output.exists()
@@ -87,7 +83,7 @@ class TransformCachingSpec extends AbstractCachingSpec {
         """.stripIndent()
 
         when:
-        assertShadowJarNotCached()
+        assertShadowJarExecutes()
 
         then:
         output.exists()
@@ -104,7 +100,7 @@ class TransformCachingSpec extends AbstractCachingSpec {
                }
             }
         """
-        assertShadowJarNotCached()
+        assertShadowJarExecutes()
 
         then:
         output.exists()
@@ -113,7 +109,7 @@ class TransformCachingSpec extends AbstractCachingSpec {
         ])
 
         when:
-        assertShadowJarCached()
+        assertShadowJarIsCachedAndRelocatable()
 
         then:
         output.exists()
@@ -130,7 +126,7 @@ class TransformCachingSpec extends AbstractCachingSpec {
                }
             }
         """
-        assertShadowJarNotCached()
+        assertShadowJarExecutes()
 
         then:
         output.exists()
@@ -139,7 +135,7 @@ class TransformCachingSpec extends AbstractCachingSpec {
         ])
 
         when:
-        assertShadowJarCached()
+        assertShadowJarIsCachedAndRelocatable()
 
         then:
         output.exists()
@@ -162,7 +158,7 @@ class TransformCachingSpec extends AbstractCachingSpec {
         """.stripIndent()
 
         when:
-        assertShadowJarNotCached()
+        assertShadowJarExecutes()
 
         then:
         output.exists()
@@ -179,7 +175,7 @@ class TransformCachingSpec extends AbstractCachingSpec {
                }
             }
         """
-        assertShadowJarNotCached()
+        assertShadowJarExecutes()
 
         then:
         output.exists()
@@ -189,7 +185,7 @@ class TransformCachingSpec extends AbstractCachingSpec {
         ])
 
         when:
-        assertShadowJarCached()
+        assertShadowJarIsCachedAndRelocatable()
 
         then:
         output.exists()
@@ -209,7 +205,7 @@ class TransformCachingSpec extends AbstractCachingSpec {
                }
             }
         """
-        assertShadowJarNotCached()
+        assertShadowJarExecutes()
 
         then:
         output.exists()
@@ -219,7 +215,7 @@ class TransformCachingSpec extends AbstractCachingSpec {
         ])
 
         when:
-        assertShadowJarCached()
+        assertShadowJarIsCachedAndRelocatable()
 
         then:
         output.exists()
@@ -243,7 +239,7 @@ class TransformCachingSpec extends AbstractCachingSpec {
         """.stripIndent()
 
         when:
-        assertShadowJarNotCached()
+        assertShadowJarExecutes()
 
         then:
         output.exists()
@@ -260,7 +256,7 @@ class TransformCachingSpec extends AbstractCachingSpec {
                }
             }
         """
-        assertShadowJarNotCached()
+        assertShadowJarExecutes()
 
         then:
         output.exists()
@@ -270,7 +266,7 @@ class TransformCachingSpec extends AbstractCachingSpec {
         ])
 
         when:
-        assertShadowJarCached()
+        assertShadowJarIsCachedAndRelocatable()
 
         then:
         output.exists()
@@ -290,7 +286,7 @@ class TransformCachingSpec extends AbstractCachingSpec {
                }
             }
         """
-        assertShadowJarNotCached()
+        assertShadowJarExecutes()
 
         then:
         output.exists()
@@ -300,7 +296,7 @@ class TransformCachingSpec extends AbstractCachingSpec {
         ])
 
         when:
-        assertShadowJarCached()
+        assertShadowJarIsCachedAndRelocatable()
 
         then:
         output.exists()
@@ -323,7 +319,7 @@ class TransformCachingSpec extends AbstractCachingSpec {
         """.stripIndent()
 
         when:
-        assertShadowJarNotCached()
+        assertShadowJarExecutes()
 
         then:
         output.exists()
@@ -338,7 +334,7 @@ class TransformCachingSpec extends AbstractCachingSpec {
                transform(${GroovyExtensionModuleTransformer.name})
             }
         """
-        assertShadowJarNotCached()
+        assertShadowJarExecutes()
 
         then:
         output.exists()
@@ -347,7 +343,7 @@ class TransformCachingSpec extends AbstractCachingSpec {
         ])
 
         when:
-        assertShadowJarCached()
+        assertShadowJarIsCachedAndRelocatable()
 
         then:
         output.exists()


### PR DESCRIPTION
These changes make the `shadowJar` task compatible with the build cache.  

The task will still be cacheable if any of the following transformers are used:

- AppendingTransformer
- XmlAppendingTransformer
- ServiceFileTransformer
- GrroovyExtensionModuleTransformer

But the other out-of-the-box transformers are not cacheable yet (if they are added, the task will be marked as un-cacheable) but I can add caching for those with a future PR.  User-defined transformers will also make the task un-cacheable unless they declare the inputs of the transformer and annotate it with `@CacheableTransformer`.

Similarly, `SimpleRelocator` has been marked as cacheable, but any custom relocators will disable caching unless the class is annotated with `@CacheableRelocator`.

We've seen fairly significant task execution times for projects with large dependency graphs, so making this task usable with the build cache could provide a decent performance improvement.

Please pay special attention to the test coverage and let me know if there are any potential edge cases not covered.  I'm happy to discuss anything if it doesn't make sense or seems wrong.