### PR TITLE
Upgrade to ASM 7.2 to support JDK 14

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -5,8 +5,8 @@ dependencies {
     shadow 'org.codehaus.groovy:groovy-backports-compat23:2.4.15'
 
     implementation 'org.jdom:jdom2:2.0.6'
-    implementation 'org.ow2.asm:asm:7.0-beta'
-    implementation 'org.ow2.asm:asm-commons:7.0-beta'
+    implementation 'org.ow2.asm:asm:7.2'
+    implementation 'org.ow2.asm:asm-commons:7.2'
     implementation 'commons-io:commons-io:2.5'
     implementation 'org.apache.ant:ant:1.9.7'
     implementation 'org.codehaus.plexus:plexus-utils:3.0.24'


### PR DESCRIPTION
Any attempt to run Gradle build with Shadow **5.2.0** on JDK 13+ fails with `Unsupported class file` exception, e.g.:
```
java.lang.IllegalArgumentException: Unsupported class file major version 57
        at shadow.org.objectweb.asm.ClassReader.<init>(ClassReader.java:184)
        at shadow.org.objectweb.asm.ClassReader.<init>(ClassReader.java:166)
        at shadow.org.objectweb.asm.ClassReader.<init>(ClassReader.java:152)
        at shadow.org.objectweb.asm.ClassReader.<init>(ClassReader.java:273)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at com.github.jengelman.gradle.plugins.shadow.tasks.ShadowCopyAction$StreamAction.remapClass(ShadowCopyAction.groovy:337)
```
This PR fixes this problem.