### PR TITLE
Optimizations to relocation checks. Up to 3x faster

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/impl/RelocatorRemapper.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/impl/RelocatorRemapper.groovy
@@ -65,13 +65,13 @@ class RelocatorRemapper extends Remapper {
                 name = m.group(2)
             }
 
-            RelocateClassContext classContext = RelocateClassContext.builder().className(name).stats(stats).build()
-            RelocatePathContext pathContext = RelocatePathContext.builder().path(name).stats(stats).build()
             for (Relocator r : relocators) {
-                if (r.canRelocateClass(classContext)) {
+                if (r.canRelocateClass(name)) {
+                    RelocateClassContext classContext = RelocateClassContext.builder().className(name).stats(stats).build()
                     value = prefix + r.relocateClass(classContext) + suffix
                     break
-                } else if (r.canRelocatePath(pathContext)) {
+                } else if (r.canRelocatePath(name)) {
+                    RelocatePathContext pathContext = RelocatePathContext.builder().path(name).stats(stats).build()
                     value = prefix + r.relocatePath(pathContext) + suffix
                     break
                 }
@@ -96,9 +96,9 @@ class RelocatorRemapper extends Remapper {
             name = m.group(2)
         }
 
-        RelocatePathContext pathContext = RelocatePathContext.builder().path(name).stats(stats).build()
         for (Relocator r : relocators) {
-            if (r.canRelocatePath(pathContext)) {
+            if (r.canRelocatePath(name)) {
+                RelocatePathContext pathContext = RelocatePathContext.builder().path(name).stats(stats).build()
                 value = prefix + r.relocatePath(pathContext) + suffix
                 break
             }

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/relocation/Relocator.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/relocation/Relocator.groovy
@@ -28,11 +28,11 @@ package com.github.jengelman.gradle.plugins.shadow.relocation
 interface Relocator {
     String ROLE = Relocator.class.getName()
 
-    boolean canRelocatePath(RelocatePathContext context)
+    boolean canRelocatePath(String path)
 
     String relocatePath(RelocatePathContext context)
 
-    boolean canRelocateClass(RelocateClassContext context)
+    boolean canRelocateClass(String className)
 
     String relocateClass(RelocateClassContext context)
 

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2PluginsCacheFileTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2PluginsCacheFileTransformer.groovy
@@ -115,8 +115,7 @@ class Log4j2PluginsCacheFileTransformer implements Transformer {
                 RelocateClassContext relocateClassContext = new RelocateClassContext(className, stats)
                 for (Relocator currentRelocator : relocators) {
                     // If we have a relocator that can relocate our current entry...
-                    boolean canRelocateClass = currentRelocator.canRelocateClass(relocateClassContext)
-                    if (canRelocateClass) {
+                    if (currentRelocator.canRelocateClass(className)) {
                         // Then we perform that relocation and update the plugin entry to reflect the new value.
                         String relocatedClassName = currentRelocator.relocateClass(relocateClassContext)
                         currentPluginEntry.setClassName(relocatedClassName)

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.groovy
@@ -71,12 +71,12 @@ class ServiceFileTransformer implements Transformer, PatternFilterable {
         def lines = context.is.readLines()
         def targetPath = context.path
         context.relocators.each {rel ->
-            if(rel.canRelocateClass(RelocateClassContext.builder().className(new File(targetPath).name).stats(context.stats).build())) {
+            if (rel.canRelocateClass(new File(targetPath).name)) {
                 targetPath = rel.relocateClass(RelocateClassContext.builder().className(targetPath).stats(context.stats).build())
             }
             lines.eachWithIndex { String line, int i ->
-                def lineContext = RelocateClassContext.builder().className(line).stats(context.stats).build()
-                if(rel.canRelocateClass(lineContext)) {
+                if (rel.canRelocateClass(line)) {
+                    def lineContext = RelocateClassContext.builder().className(line).stats(context.stats).build()
                     lines[i] = rel.relocateClass(lineContext)
                 }
             }

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocatorTest.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocatorTest.groovy
@@ -46,78 +46,91 @@ class SimpleRelocatorTest extends TestCase {
         SimpleRelocator relocator
 
         relocator = new SimpleRelocator("org.foo", null, null, null)
-        assertEquals(true, relocator.canRelocatePath(pathContext("org/foo/Class")))
-        assertEquals(true, relocator.canRelocatePath(pathContext("org/foo/Class.class")))
-        assertEquals(true, relocator.canRelocatePath(pathContext("org/foo/bar/Class")))
-        assertEquals(true, relocator.canRelocatePath(pathContext("org/foo/bar/Class.class")))
-        assertEquals(false, relocator.canRelocatePath(pathContext("com/foo/bar/Class")))
-        assertEquals(false, relocator.canRelocatePath(pathContext("com/foo/bar/Class.class")))
-        assertEquals(false, relocator.canRelocatePath(pathContext("org/Foo/Class")))
-        assertEquals(false, relocator.canRelocatePath(pathContext("org/Foo/Class.class")))
+        assertEquals(true, relocator.canRelocatePath("org/foo/Class"))
+        assertEquals(true, relocator.canRelocatePath("org/foo/Class.class"))
+        assertEquals(true, relocator.canRelocatePath("org/foo/bar/Class"))
+        assertEquals(true, relocator.canRelocatePath("org/foo/bar/Class.class"))
+        assertEquals(false, relocator.canRelocatePath("com/foo/bar/Class"))
+        assertEquals(false, relocator.canRelocatePath("com/foo/bar/Class.class"))
+        assertEquals(false, relocator.canRelocatePath("org/Foo/Class"))
+        assertEquals(false, relocator.canRelocatePath("org/Foo/Class.class"))
+
+        // Verify paths starting with '/'
+        assertEquals(false, relocator.canRelocatePath("/org/Foo/Class"))
+        assertEquals(false, relocator.canRelocatePath("/org/Foo/Class.class"))
 
         relocator = new SimpleRelocator("org.foo", null, null, Arrays.asList(
                 [ "org.foo.Excluded", "org.foo.public.*", "org.foo.recurse.**", "org.foo.Public*Stuff" ] as String[]))
-        assertEquals(true, relocator.canRelocatePath(pathContext("org/foo/Class")))
-        assertEquals(true, relocator.canRelocatePath(pathContext("org/foo/Class.class")))
-        assertEquals(true, relocator.canRelocatePath(pathContext("org/foo/excluded")))
-        assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/Excluded")))
-        assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/Excluded.class")))
-        assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/public")))
-        assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/public/Class")))
-        assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/public/Class.class")))
-        assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/public/sub")))
-        assertEquals(true, relocator.canRelocatePath(pathContext("org/foo/public/sub/Class")))
-        assertEquals(true, relocator.canRelocatePath(pathContext("org/foo/publicRELOC/Class")))
-        assertEquals(true, relocator.canRelocatePath(pathContext("org/foo/PrivateStuff")))
-        assertEquals(true, relocator.canRelocatePath(pathContext("org/foo/PrivateStuff.class")))
-        assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/PublicStuff")))
-        assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/PublicStuff.class")))
-        assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/PublicUtilStuff")))
-        assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/PublicUtilStuff.class")))
-        assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/recurse")))
-        assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/recurse/Class")))
-        assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/recurse/Class.class")))
-        assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/recurse/sub")))
-        assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/recurse/sub/Class")))
-        assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/recurse/sub/Class.class")))
+        assertEquals(true, relocator.canRelocatePath("org/foo/Class"))
+        assertEquals(true, relocator.canRelocatePath("org/foo/Class.class"))
+        assertEquals(true, relocator.canRelocatePath("org/foo/excluded"))
+        assertEquals(false, relocator.canRelocatePath("org/foo/Excluded"))
+        assertEquals(false, relocator.canRelocatePath("org/foo/Excluded.class"))
+        assertEquals(false, relocator.canRelocatePath("org/foo/public"))
+        assertEquals(false, relocator.canRelocatePath("org/foo/public/Class"))
+        assertEquals(false, relocator.canRelocatePath("org/foo/public/Class.class"))
+        assertEquals(false, relocator.canRelocatePath("org/foo/public/sub"))
+        assertEquals(true, relocator.canRelocatePath("org/foo/public/sub/Class"))
+        assertEquals(true, relocator.canRelocatePath("org/foo/publicRELOC/Class"))
+        assertEquals(true, relocator.canRelocatePath("org/foo/PrivateStuff"))
+        assertEquals(true, relocator.canRelocatePath("org/foo/PrivateStuff.class"))
+        assertEquals(false, relocator.canRelocatePath("org/foo/PublicStuff"))
+        assertEquals(false, relocator.canRelocatePath("org/foo/PublicStuff.class"))
+        assertEquals(false, relocator.canRelocatePath("org/foo/PublicUtilStuff"))
+        assertEquals(false, relocator.canRelocatePath("org/foo/PublicUtilStuff.class"))
+        assertEquals(false, relocator.canRelocatePath("org/foo/recurse"))
+        assertEquals(false, relocator.canRelocatePath("org/foo/recurse/Class"))
+        assertEquals(false, relocator.canRelocatePath("org/foo/recurse/Class.class"))
+        assertEquals(false, relocator.canRelocatePath("org/foo/recurse/sub"))
+        assertEquals(false, relocator.canRelocatePath("org/foo/recurse/sub/Class"))
+        assertEquals(false, relocator.canRelocatePath("org/foo/recurse/sub/Class.class"))
+
+        // Verify edge cases
+        relocator = new SimpleRelocator("org.f", null, null, null)
+        assertEquals(false, relocator.canRelocatePath(""))       // Empty path
+        assertEquals(false, relocator.canRelocatePath(".class")) // only .class
+        assertEquals(false, relocator.canRelocatePath("te"))     // shorter than path pattern
+        assertEquals(false, relocator.canRelocatePath("test"))   // shorter than path pattern with /
+        assertEquals(true, relocator.canRelocatePath("org/f"))   // equal to path pattern
+        assertEquals(true, relocator.canRelocatePath("/org/f"))  // equal to path pattern with /
     }
 
     void testCanRelocateClass() {
         SimpleRelocator relocator
 
         relocator = new SimpleRelocator("org.foo", null, null, null)
-        assertEquals(true, relocator.canRelocateClass(classContext("org.foo.Class")))
-        assertEquals(true, relocator.canRelocateClass(classContext("org.foo.bar.Class")))
-        assertEquals(false, relocator.canRelocateClass(classContext("com.foo.bar.Class")))
-        assertEquals(false, relocator.canRelocateClass(classContext("org.Foo.Class")))
+        assertEquals(true, relocator.canRelocateClass("org.foo.Class"))
+        assertEquals(true, relocator.canRelocateClass("org.foo.bar.Class"))
+        assertEquals(false, relocator.canRelocateClass("com.foo.bar.Class"))
+        assertEquals(false, relocator.canRelocateClass("org.Foo.Class"))
 
         relocator = new SimpleRelocator("org.foo", null, null, Arrays.asList(
                 [ "org.foo.Excluded", "org.foo.public.*", "org.foo.recurse.**", "org.foo.Public*Stuff" ] as String[]))
-        assertEquals(true, relocator.canRelocateClass(classContext("org.foo.Class")))
-        assertEquals(true, relocator.canRelocateClass(classContext("org.foo.excluded")))
-        assertEquals(false, relocator.canRelocateClass(classContext("org.foo.Excluded")))
-        assertEquals(false, relocator.canRelocateClass(classContext("org.foo.public")))
-        assertEquals(false, relocator.canRelocateClass(classContext("org.foo.public.Class")))
-        assertEquals(false, relocator.canRelocateClass(classContext("org.foo.public.sub")))
-        assertEquals(true, relocator.canRelocateClass(classContext("org.foo.public.sub.Class")))
-        assertEquals(true, relocator.canRelocateClass(classContext("org.foo.publicRELOC.Class")))
-        assertEquals(true, relocator.canRelocateClass(classContext("org.foo.PrivateStuff")))
-        assertEquals(false, relocator.canRelocateClass(classContext("org.foo.PublicStuff")))
-        assertEquals(false, relocator.canRelocateClass(classContext("org.foo.PublicUtilStuff")))
-        assertEquals(false, relocator.canRelocateClass(classContext("org.foo.recurse")))
-        assertEquals(false, relocator.canRelocateClass(classContext("org.foo.recurse.Class")))
-        assertEquals(false, relocator.canRelocateClass(classContext("org.foo.recurse.sub")))
-        assertEquals(false, relocator.canRelocateClass(classContext("org.foo.recurse.sub.Class")))
+        assertEquals(true, relocator.canRelocateClass("org.foo.Class"))
+        assertEquals(true, relocator.canRelocateClass("org.foo.excluded"))
+        assertEquals(false, relocator.canRelocateClass("org.foo.Excluded"))
+        assertEquals(false, relocator.canRelocateClass("org.foo.public"))
+        assertEquals(false, relocator.canRelocateClass("org.foo.public.Class"))
+        assertEquals(false, relocator.canRelocateClass("org.foo.public.sub"))
+        assertEquals(true, relocator.canRelocateClass("org.foo.public.sub.Class"))
+        assertEquals(true, relocator.canRelocateClass("org.foo.publicRELOC.Class"))
+        assertEquals(true, relocator.canRelocateClass("org.foo.PrivateStuff"))
+        assertEquals(false, relocator.canRelocateClass("org.foo.PublicStuff"))
+        assertEquals(false, relocator.canRelocateClass("org.foo.PublicUtilStuff"))
+        assertEquals(false, relocator.canRelocateClass("org.foo.recurse"))
+        assertEquals(false, relocator.canRelocateClass("org.foo.recurse.Class"))
+        assertEquals(false, relocator.canRelocateClass("org.foo.recurse.sub"))
+        assertEquals(false, relocator.canRelocateClass("org.foo.recurse.sub.Class"))
     }
 
     void testCanRelocateRawString() {
         SimpleRelocator relocator
 
         relocator = new SimpleRelocator("org/foo", null, null, null, true)
-        assertEquals(true, relocator.canRelocatePath(pathContext("(I)org/foo/bar/Class")))
+        assertEquals(true, relocator.canRelocatePath("(I)org/foo/bar/Class"))
 
         relocator = new SimpleRelocator("^META-INF/org.foo.xml\$", null, null, null, true)
-        assertEquals(true, relocator.canRelocatePath(pathContext("META-INF/org.foo.xml")))
+        assertEquals(true, relocator.canRelocatePath("META-INF/org.foo.xml"))
     }
 
     //MSHADE-119, make sure that the easy part of this works.


### PR DESCRIPTION
Performance boost on large project (5:48 -> 2:02 min total duration).

- Changed signature of methods to accept `String` as path instead of `RelocatePathContext`/`RelocateClassContext` to prevent unnecessary allocations for builder objects
- Added extra string length checks to avoid string operations where possible
- Reordered checks in `canRelocateClass` so that expensive string replacement is the last operation
- (Main Optimization) Avoided string concatenation (which led to creating `StringBuilder` instances and expensive array copy operations) by adding check for first character being `/`: if so - perform a `startsWith` check with an offset.