### PR TITLE
Fix excludes ant pattern on Windows

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocator.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocator.groovy
@@ -123,7 +123,7 @@ class SimpleRelocator implements Relocator {
     private boolean isIncluded(String path) {
         if (includes != null && !includes.isEmpty()) {
             for (String include : includes) {
-                if (SelectorUtils.matchPath(include, path, true)) {
+                if (SelectorUtils.matchPath(include, path, '/', true)) {
                     return true
                 }
             }
@@ -135,7 +135,7 @@ class SimpleRelocator implements Relocator {
     private boolean isExcluded(String path) {
         if (excludes != null && !excludes.isEmpty()) {
             for (String exclude : excludes) {
-                if (SelectorUtils.matchPath(exclude, path, true)) {
+                if (SelectorUtils.matchPath(exclude, path, '/', true)) {
                     return true
                 }
             }

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocatorTest.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocatorTest.groovy
@@ -56,7 +56,7 @@ class SimpleRelocatorTest extends TestCase {
         assertEquals(false, relocator.canRelocatePath(pathContext("org/Foo/Class.class")))
 
         relocator = new SimpleRelocator("org.foo", null, null, Arrays.asList(
-                [ "org.foo.Excluded", "org.foo.public.*", "org.foo.Public*Stuff" ] as String[]))
+                [ "org.foo.Excluded", "org.foo.public.*", "org.foo.recurse.**", "org.foo.Public*Stuff" ] as String[]))
         assertEquals(true, relocator.canRelocatePath(pathContext("org/foo/Class")))
         assertEquals(true, relocator.canRelocatePath(pathContext("org/foo/Class.class")))
         assertEquals(true, relocator.canRelocatePath(pathContext("org/foo/excluded")))
@@ -65,6 +65,8 @@ class SimpleRelocatorTest extends TestCase {
         assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/public")))
         assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/public/Class")))
         assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/public/Class.class")))
+        assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/public/sub")))
+        assertEquals(true, relocator.canRelocatePath(pathContext("org/foo/public/sub/Class")))
         assertEquals(true, relocator.canRelocatePath(pathContext("org/foo/publicRELOC/Class")))
         assertEquals(true, relocator.canRelocatePath(pathContext("org/foo/PrivateStuff")))
         assertEquals(true, relocator.canRelocatePath(pathContext("org/foo/PrivateStuff.class")))
@@ -72,6 +74,12 @@ class SimpleRelocatorTest extends TestCase {
         assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/PublicStuff.class")))
         assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/PublicUtilStuff")))
         assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/PublicUtilStuff.class")))
+        assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/recurse")))
+        assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/recurse/Class")))
+        assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/recurse/Class.class")))
+        assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/recurse/sub")))
+        assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/recurse/sub/Class")))
+        assertEquals(false, relocator.canRelocatePath(pathContext("org/foo/recurse/sub/Class.class")))
     }
 
     void testCanRelocateClass() {
@@ -84,16 +92,22 @@ class SimpleRelocatorTest extends TestCase {
         assertEquals(false, relocator.canRelocateClass(classContext("org.Foo.Class")))
 
         relocator = new SimpleRelocator("org.foo", null, null, Arrays.asList(
-                [ "org.foo.Excluded", "org.foo.public.*", "org.foo.Public*Stuff" ] as String[]))
+                [ "org.foo.Excluded", "org.foo.public.*", "org.foo.recurse.**", "org.foo.Public*Stuff" ] as String[]))
         assertEquals(true, relocator.canRelocateClass(classContext("org.foo.Class")))
         assertEquals(true, relocator.canRelocateClass(classContext("org.foo.excluded")))
         assertEquals(false, relocator.canRelocateClass(classContext("org.foo.Excluded")))
         assertEquals(false, relocator.canRelocateClass(classContext("org.foo.public")))
         assertEquals(false, relocator.canRelocateClass(classContext("org.foo.public.Class")))
+        assertEquals(false, relocator.canRelocateClass(classContext("org.foo.public.sub")))
+        assertEquals(true, relocator.canRelocateClass(classContext("org.foo.public.sub.Class")))
         assertEquals(true, relocator.canRelocateClass(classContext("org.foo.publicRELOC.Class")))
         assertEquals(true, relocator.canRelocateClass(classContext("org.foo.PrivateStuff")))
         assertEquals(false, relocator.canRelocateClass(classContext("org.foo.PublicStuff")))
         assertEquals(false, relocator.canRelocateClass(classContext("org.foo.PublicUtilStuff")))
+        assertEquals(false, relocator.canRelocateClass(classContext("org.foo.recurse")))
+        assertEquals(false, relocator.canRelocateClass(classContext("org.foo.recurse.Class")))
+        assertEquals(false, relocator.canRelocateClass(classContext("org.foo.recurse.sub")))
+        assertEquals(false, relocator.canRelocateClass(classContext("org.foo.recurse.sub.Class")))
     }
 
     void testCanRelocateRawString() {


### PR DESCRIPTION
Fixes this use case on Windows:

```
  relocate('io.opentelemetry', 'io.opentelemetry.auto.shaded.io.opentelemetry') {
    exclude 'io.opentelemetry.auto.**'
  }
```

The fix is to explicitly pass separator (`/`) to `SelectorUtils.matchPath`. The default when it's not passed is `File.separator`, so this change should have no effect on non-Windows OS.
