### PR TITLE
Support project dependencies in the shadow configuration

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowExtension.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowExtension.groovy
@@ -1,6 +1,7 @@
 package com.github.jengelman.gradle.plugins.shadow
 
 import org.gradle.api.Project
+import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.SelfResolvingDependency
 import org.gradle.api.file.CopySpec
 import org.gradle.api.publish.maven.MavenPom
@@ -24,7 +25,7 @@ class ShadowExtension {
                 def dependenciesNode = xml.asNode().appendNode('dependencies')
 
                 project.configurations.shadow.allDependencies.each {
-                    if (! (it instanceof SelfResolvingDependency)) {
+                    if ((it instanceof ProjectDependency) || ! (it instanceof SelfResolvingDependency)) {
                         def dependencyNode = dependenciesNode.appendNode('dependency')
                         dependencyNode.appendNode('groupId', it.group)
                         dependencyNode.appendNode('artifactId', it.name)

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/PublishingSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/PublishingSpec.groovy
@@ -164,4 +164,101 @@ class PublishingSpec extends PluginSpecification {
         assert dependency.artifactId.text() == 'b'
         assert dependency.version.text() == '1.0'
     }
+
+    def "publish multiproject shadow jar with maven-publish plugin"() {
+        given:
+
+        settingsFile << """
+            rootProject.name = 'maven'
+            include 'a'
+            include 'b'
+            include 'c'
+        """.stripMargin()
+
+        buildFile.text = """
+            subprojects {
+                apply plugin: 'java'
+                apply plugin: 'maven-publish'
+
+                version = "1.0"
+                group = 'shadow'
+    
+                repositories { maven { url "${repo.uri}" } }
+                publishing {
+                   repositories {
+                       maven {
+                           url "${publishingRepo.uri}"
+                       }
+                   }
+                }
+            }
+        """.stripIndent()
+
+        file('a/build.gradle') << """
+            plugins {
+                id 'java'
+                id 'maven-publish'
+            }
+        """.stripMargin()
+
+        file('a/src/main/resources/a.properties') << 'a'
+        file('a/src/main/resources/a2.properties') << 'a2'
+
+        file('b/build.gradle') << """
+            plugins {
+                id 'java'
+                id 'maven-publish'
+            }
+        """.stripMargin()
+
+        file('b/src/main/resources/b.properties') << 'b'
+
+        file('c/build.gradle') << """
+            plugins {
+                id 'com.github.johnrengelman.shadow'
+            }
+            
+            dependencies {
+                compile project(':a')
+                shadow project(':b')
+            }
+
+            shadowJar {
+               classifier = ''
+               baseName = 'maven-all'
+            }
+            
+            publishing {
+               publications {
+                   shadow(MavenPublication) { publication ->
+                       project.shadow.component(publication)
+                       artifactId = 'maven-all'
+                   }
+               }
+            }
+        """.stripMargin()
+
+        when:
+        runner.withArguments('publish').build()
+
+        then:
+        File publishedFile = publishingRepo.rootDir.file('shadow/maven-all/1.0/maven-all-1.0.jar').canonicalFile
+        assert publishedFile.exists()
+
+        and:
+        contains(publishedFile, ['a.properties', 'a2.properties'])
+
+        and:
+        File pom = publishingRepo.rootDir.file('shadow/maven-all/1.0/maven-all-1.0.pom').canonicalFile
+        assert pom.exists()
+
+        def contents = new XmlSlurper().parse(pom)
+        assert contents.dependencies.size() == 1
+        assert contents.dependencies[0].dependency.size() == 1
+
+        def dependency = contents.dependencies[0].dependency[0]
+        assert dependency.groupId.text() == 'shadow'
+        assert dependency.artifactId.text() == 'b'
+        assert dependency.version.text() == '1.0'
+    }
 }


### PR DESCRIPTION
When  dependencies in the `shadow` configuration are project dependencies, expose them in the `.pom` in the same way as dependencies on external modules.

Use case: a multi-project build that publishes API and implementation in separate jars, where the implementation is a shadow jar and needs a dependency on the API.

Fix for #541.