### PR TITLE
Eliminate serviceEntries deprecation warning by making it private

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.groovy
@@ -51,7 +51,7 @@ class ServiceFileTransformer implements Transformer, PatternFilterable {
     private static final String GROOVY_EXTENSION_MODULE_DESCRIPTOR_PATTERN =
             "META-INF/services/org.codehaus.groovy.runtime.ExtensionModule"
 
-    Map<String, ServiceStream> serviceEntries = [:].withDefault { new ServiceStream() }
+    private Map<String, ServiceStream> serviceEntries = [:].withDefault { new ServiceStream() }
 
     private final PatternSet patternSet =
             new PatternSet().include(SERVICES_PATTERN).exclude(GROOVY_EXTENSION_MODULE_DESCRIPTOR_PATTERN)


### PR DESCRIPTION
Fixes #530 

I ran a test between HEAD and this:

- HEAD (43a8d4e8ea5d07a29d1d012c16fd4e34f646f87c):
```
% ./gradlew --warning-mode=all shadowJar
Starting a Gradle Daemon (subsequent builds will be faster)

> Task :shadowJar
Property 'transformers.$0.serviceEntries' is not annotated with an input or output annotation. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.3/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.

BUILD SUCCESSFUL in 30s
2 actionable tasks: 2 executed
```

- this change:
```
% ./gradlew --warning-mode=all shadowJar

BUILD SUCCESSFUL in 6s
2 actionable tasks: 1 executed, 1 up-to-date
```

I also verified that the contents of the `META-INF/services` files were the same. I also ran an incremental build (first `clean shadowJar` then `shadowJar`) and the result was the same.