### PR TITLE
Update runShadow configuration

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.groovy
@@ -5,7 +5,6 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.distribution.Distribution
 import org.gradle.api.distribution.DistributionContainer
 import org.gradle.api.file.CopySpec
@@ -71,6 +70,7 @@ class ShadowApplicationPlugin implements Plugin<Project> {
         def run = project.tasks.create(SHADOW_RUN_TASK_NAME, JavaJarExec)
         Sync install = project.tasks.getByName(SHADOW_INSTALL_TASK_NAME)
         run.dependsOn SHADOW_INSTALL_TASK_NAME
+        run.setMain('-jar')
         run.description  = 'Runs this project as a JVM application using the shadow jar'
         run.group = ApplicationPlugin.APPLICATION_GROUP
         run.conventionMapping.jvmArgs = { pluginConvention.applicationDefaultJvmArgs }

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/JavaJarExec.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/JavaJarExec.groovy
@@ -2,7 +2,6 @@ package com.github.jengelman.gradle.plugins.shadow.internal
 
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.JavaExec
-import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 
 class JavaJarExec extends JavaExec {
@@ -13,7 +12,6 @@ class JavaJarExec extends JavaExec {
     @Override
     @TaskAction
     public void exec() {
-        setMain('-jar')
         List<String> allArgs = [getJarFile().path] + getArgs()
         setArgs(allArgs)
         super.exec()


### PR DESCRIPTION
This resolves the compatibility issue with Gradle 6.4+ caused
by changing task configuration at execution.

Fixes #574