### PR TITLE
Fixes to allow Configuration Caching in Gradle 6.6+

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.groovy
@@ -54,12 +54,10 @@ class ShadowApplicationPlugin implements Plugin<Project> {
     }
 
     protected void configureJarMainClass(Project project) {
-        ApplicationPluginConvention pluginConvention = (
-                ApplicationPluginConvention) project.convention.plugins.application
-
-        jar.inputs.property('mainClassName', { pluginConvention.mainClassName })
+        def classNameProvider = project.provider { project.convention.plugins.application.mainClassName }
+        jar.inputs.property('mainClassName', classNameProvider)
         jar.doFirst {
-            manifest.attributes 'Main-Class': pluginConvention.mainClassName
+            manifest.attributes 'Main-Class': classNameProvider.get()
         }
     }
 
@@ -93,7 +91,7 @@ class ShadowApplicationPlugin implements Plugin<Project> {
         startScripts.conventionMapping.applicationName = { pluginConvention.applicationName }
         startScripts.conventionMapping.outputDir = { new File(project.buildDir, 'scriptsShadow') }
         startScripts.conventionMapping.defaultJvmOpts = { pluginConvention.applicationDefaultJvmArgs }
-        startScripts.inputs.files jar
+        startScripts.inputs.files project.objects.fileCollection().from { -> jar }
 
     }
 

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.groovy
@@ -7,10 +7,9 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.maven.Conf2ScopeMappingContainer
 import org.gradle.api.artifacts.maven.MavenPom
 import org.gradle.api.attributes.Bundling
-import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.attributes.Category
+import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.attributes.Usage
-import org.gradle.api.attributes.java.TargetJvmVersion
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.plugins.MavenPlugin
 import org.gradle.api.tasks.Upload
@@ -77,10 +76,13 @@ class ShadowJavaPlugin implements Plugin<Project> {
             }
         }
         shadow.manifest.inheritFrom project.tasks.jar.manifest
+        def libsProvider = project.provider { -> [project.tasks.jar.manifest.attributes.get('Class-Path')] }
+        def files = project.objects.fileCollection().from { ->
+            project.configurations.findByName(ShadowBasePlugin.CONFIGURATION_NAME)
+        }
         shadow.doFirst {
-            def files = project.configurations.findByName(ShadowBasePlugin.CONFIGURATION_NAME).files
-            if (files) {
-                def libs = [project.tasks.jar.manifest.attributes.get('Class-Path')]
+            if (!files.empty) {
+                def libs = libsProvider.get()
                 libs.addAll files.collect { "${it.name}" }
                 manifest.attributes 'Class-Path': libs.findAll { it }.join(' ')
             }

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.java
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.java
@@ -9,6 +9,7 @@ import com.github.jengelman.gradle.plugins.shadow.transformers.*;
 import org.gradle.api.Action;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DuplicatesStrategy;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.DocumentationRegistry;
@@ -30,12 +31,20 @@ public class ShadowJar extends Jar implements ShadowSpec {
     private List<Transformer> transformers;
     private List<Relocator> relocators;
     private List<Configuration> configurations;
-    private DependencyFilter dependencyFilter;
+    private transient DependencyFilter dependencyFilter;
     private boolean minimizeJar;
-    private DependencyFilter dependencyFilterForMinimize;
+    private transient DependencyFilter dependencyFilterForMinimize;
 
     private final ShadowStats shadowStats = new ShadowStats();
     private final GradleVersionUtil versionUtil;
+
+    private final ConfigurableFileCollection includedDependencies = getProject().files(new Callable<FileCollection>() {
+
+        @Override
+        public FileCollection call() throws Exception {
+            return dependencyFilter.resolve(configurations);
+        }
+    });
 
     public ShadowJar() {
         super();
@@ -119,13 +128,7 @@ public class ShadowJar extends Jar implements ShadowSpec {
 
     @Classpath
     public FileCollection getIncludedDependencies() {
-        return getProject().files(new Callable<FileCollection>() {
-
-            @Override
-            public FileCollection call() throws Exception {
-                return dependencyFilter.resolve(configurations);
-            }
-        });
+        return includedDependencies;
     }
 
     /**

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ConfigurationCacheSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ConfigurationCacheSpec.groovy
@@ -1,0 +1,87 @@
+package com.github.jengelman.gradle.plugins.shadow
+
+import com.github.jengelman.gradle.plugins.shadow.util.PluginSpecification
+import org.gradle.util.GradleVersion
+import spock.lang.IgnoreIf
+
+@IgnoreIf({ GradleVersion.current().baseVersion < GradleVersion.version("6.6") })
+class ConfigurationCacheSpec extends PluginSpecification {
+
+    def setup() {
+        repo.module('shadow', 'a', '1.0')
+                .insertFile('a.properties', 'a')
+                .insertFile('a2.properties', 'a2')
+                .publish()
+        repo.module('shadow', 'b', '1.0')
+                .insertFile('b.properties', 'b')
+                .publish()
+
+        buildFile << """
+            dependencies {
+               compile 'shadow:a:1.0'
+               compile 'shadow:b:1.0'
+            }
+        """.stripIndent()
+    }
+
+    def "supports configuration cache"() {
+        given:
+        repo.module('shadow', 'a', '1.0')
+                .insertFile('a.properties', 'a')
+                .insertFile('a2.properties', 'a2')
+                .publish()
+
+        file('src/main/java/myapp/Main.java') << """
+            package myapp;
+            public class Main {
+               public static void main(String[] args) {
+                   System.out.println("TestApp: Hello World! (" + args[0] + ")");
+               }
+            }
+        """.stripIndent()
+
+        buildFile << """
+            apply plugin: 'application'
+
+            mainClassName = 'myapp.Main'
+            
+            dependencies {
+               compile 'shadow:a:1.0'
+            }
+            
+            runShadow {
+               args 'foo'
+            }
+        """.stripIndent()
+
+        settingsFile << "rootProject.name = 'myapp'"
+
+        when:
+        runner.withArguments('--configuration-cache', 'shadowJar').build()
+        def result = runner.withArguments('--configuration-cache', 'shadowJar').build()
+
+        then:
+        result.output.contains("Reusing configuration cache.")
+    }
+
+    def "configuration caching supports includes"() {
+        given:
+        buildFile << """
+            shadowJar {
+               exclude 'a2.properties'
+            }
+        """.stripIndent()
+
+        when:
+        runner.withArguments('--configuration-cache', 'shadowJar').build()
+        output.delete()
+        def result = runner.withArguments('--configuration-cache', 'shadowJar').build()
+
+        then:
+        contains(output, ['a.properties', 'b.properties'])
+
+        and:
+        doesNotContain(output, ['a2.properties'])
+        result.output.contains("Reusing configuration cache.")
+    }
+}

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ConfigurationCacheSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ConfigurationCacheSpec.groovy
@@ -1,7 +1,6 @@
 package com.github.jengelman.gradle.plugins.shadow
 
 import com.github.jengelman.gradle.plugins.shadow.util.PluginSpecification
-import groovy.transform.NotYetImplemented
 import org.gradle.util.GradleVersion
 import spock.lang.IgnoreIf
 
@@ -81,7 +80,6 @@ class ConfigurationCacheSpec extends PluginSpecification {
         result.output.contains("Reusing configuration cache.")
     }
 
-    @NotYetImplemented
     def "configuration caching supports minimize"() {
         given:
         file('settings.gradle') << """

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ConfigurationCacheSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ConfigurationCacheSpec.groovy
@@ -1,10 +1,7 @@
 package com.github.jengelman.gradle.plugins.shadow
 
 import com.github.jengelman.gradle.plugins.shadow.util.PluginSpecification
-import org.gradle.util.GradleVersion
-import spock.lang.IgnoreIf
 
-@IgnoreIf({ GradleVersion.current().baseVersion < GradleVersion.version("6.6") })
 class ConfigurationCacheSpec extends PluginSpecification {
 
     def setup() {

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ConfigurationCacheSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ConfigurationCacheSpec.groovy
@@ -27,11 +27,6 @@ class ConfigurationCacheSpec extends PluginSpecification {
 
     def "supports configuration cache"() {
         given:
-        repo.module('shadow', 'a', '1.0')
-                .insertFile('a.properties', 'a')
-                .insertFile('a2.properties', 'a2')
-                .publish()
-
         file('src/main/java/myapp/Main.java') << """
             package myapp;
             public class Main {


### PR DESCRIPTION
We (myself and @britter) believe this PR allows the Shadow Plugin to be used
in a Gradle 6.6+ build with --configuration-cache enabled.

We unfortunately did not get round to fixing the case where `minimize()` is
used, so it does not work if that is called in the build.

We're basically looking for suggestions on what we can do to improve it,
or whether it is good enough to go in as-is

Cheers

Tim (and Benedikt)