### PR TITLE
Make sure the plugin can be used with Gradle 7

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.groovy
@@ -10,7 +10,6 @@ import org.gradle.api.distribution.DistributionContainer
 import org.gradle.api.file.CopySpec
 import org.gradle.api.plugins.ApplicationPlugin
 import org.gradle.api.plugins.ApplicationPluginConvention
-import org.gradle.api.plugins.MavenPlugin
 import org.gradle.api.tasks.Sync
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.application.CreateStartScripts
@@ -40,7 +39,7 @@ class ShadowApplicationPlugin implements Plugin<Project> {
         configureJarMainClass(project)
         configureInstallTask(project)
 
-        project.plugins.withType(MavenPlugin) {
+        project.pluginManager.withPlugin('maven') {
             project.configurations.archives.with {
                 artifacts.findAll {
                     if (it.hasProperty("provider")) {

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.groovy
@@ -98,7 +98,7 @@ class ShadowJavaPlugin implements Plugin<Project> {
     private void configureShadowUpload() {
         configurationActionContainer.add(new Action<Project>() {
             void execute(Project project) {
-                project.plugins.withType(MavenPlugin) {
+                project.pluginManager.withPlugin('maven') {
                     project.tasks.withType(Upload).configureEach { upload ->
                         if (upload.name != SHADOW_UPLOAD_TASK) {
                             return


### PR DESCRIPTION
Gradle 7 removes the `maven` plugin so even if you compile with an older
version and have the types available, it's possible that they are missing
at runtime.

To workaround this, this commit uses `pluginManager.withPlugin('maven')`
instead which doesn't need any type available on classpath.