### PR TITLE
Close FileInputStream when remapping class

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.groovy
@@ -323,7 +323,12 @@ class ShadowCopyAction implements CopyAction {
 
         private void remapClass(FileCopyDetails fileCopyDetails) {
             if (FilenameUtils.getExtension(fileCopyDetails.name) == 'class') {
-                remapClass(fileCopyDetails.file.newInputStream(), fileCopyDetails.path, fileCopyDetails.lastModified)
+                InputStream is = fileCopyDetails.file.newInputStream()
+                try {
+                    remapClass(is, fileCopyDetails.path, fileCopyDetails.lastModified)
+                } finally {
+                    is.close()
+                }
             }
         }
 


### PR DESCRIPTION
This fixes an issue @CarterWilliam found where the Gradle daemon locks class files.

[log.txt](https://github.com/johnrengelman/shadow/files/6044833/log.txt)
