### PR TITLE
Add input/output annotations to transformers

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.groovy
@@ -23,6 +23,9 @@ import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
 import org.codehaus.plexus.util.StringUtils
 import org.gradle.api.file.FileTreeElement
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
 
 import java.text.SimpleDateFormat
 
@@ -34,34 +37,48 @@ import java.text.SimpleDateFormat
  * @author John Engelman
  */
 class ApacheNoticeResourceTransformer implements Transformer {
+    @Internal
     Set<String> entries = new LinkedHashSet<String>()
 
+    @Internal
     Map<String, Set<String>> organizationEntries = new LinkedHashMap<String, Set<String>>()
 
+    @Input
     String projectName = "" // MSHADE-101 :: NullPointerException when projectName is missing
 
+    @Input
     boolean addHeader = true
 
+    @Input
     String preamble1 = "// ------------------------------------------------------------------\n" +
             "// NOTICE file corresponding to the section 4d of The Apache License,\n" +
             "// Version 2.0, in this case for "
 
+    @Input
     String preamble2 = "\n// ------------------------------------------------------------------\n"
 
+    @Input
     String preamble3 = "This product includes software developed at\n"
 
     //defaults overridable via config in pom
+    @Input
     String organizationName = "The Apache Software Foundation"
 
+    @Input
     String organizationURL = "http://www.apache.org/"
 
+    @Input
     String inceptionYear = "2006"
 
+    @Optional
+    @Input
     String copyright
 
     /**
      * The file encoding of the <code>NOTICE</code> file.
      */
+    @Optional
+    @Input
     String encoding
 
     private static final String NOTICE_PATH = "META-INF/NOTICE"

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformer.groovy
@@ -24,6 +24,8 @@ import org.apache.tools.zip.ZipOutputStream
 import org.codehaus.plexus.util.IOUtil
 import org.gradle.api.file.FileTreeElement
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
 
 /**
  * A resource processor that appends content for a resource, separated by a newline.
@@ -35,8 +37,11 @@ import org.gradle.api.tasks.Input
  */
 @CacheableTransformer
 class AppendingTransformer implements Transformer {
+    @Optional
+    @Input
     String resource
 
+    @Internal
     ByteArrayOutputStream data = new ByteArrayOutputStream()
 
     boolean canTransformResource(FileTreeElement element) {
@@ -66,10 +71,5 @@ class AppendingTransformer implements Transformer {
 
         IOUtil.copy(new ByteArrayInputStream(data.toByteArray()), os)
         data.reset()
-    }
-
-    @Input
-    String getResource() {
-        return resource
     }
 }

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformer.groovy
@@ -22,13 +22,14 @@ package com.github.jengelman.gradle.plugins.shadow.transformers
 import com.github.jengelman.gradle.plugins.shadow.relocation.Relocator
 import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
-import org.gradle.api.file.FileTreeElement
 import org.codehaus.plexus.util.IOUtil
 import org.codehaus.plexus.util.ReaderFactory
 import org.codehaus.plexus.util.WriterFactory
 import org.codehaus.plexus.util.xml.Xpp3Dom
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder
 import org.codehaus.plexus.util.xml.Xpp3DomWriter
+import org.gradle.api.file.FileTreeElement
+import org.gradle.api.tasks.Internal
 
 /**
  * A resource processor that aggregates plexus <code>components.xml</code> files.
@@ -129,6 +130,7 @@ class ComponentsXmlResourceTransformer implements Transformer {
         return !components.isEmpty()
     }
 
+    @Internal
     byte[] getTransformedResource()
     throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream(1024 * 4)

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/DontIncludeResourceTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/DontIncludeResourceTransformer.groovy
@@ -21,6 +21,7 @@ package com.github.jengelman.gradle.plugins.shadow.transformers
 
 import org.apache.tools.zip.ZipOutputStream
 import org.gradle.api.file.FileTreeElement
+import org.gradle.api.tasks.Input
 
 /**
  * A resource processor that prevents the inclusion of an arbitrary
@@ -31,6 +32,7 @@ import org.gradle.api.file.FileTreeElement
  * @author John Engelman
  */
 class DontIncludeResourceTransformer implements Transformer {
+    @Input
     String resource
 
     boolean canTransformResource(FileTreeElement element) {

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/IncludeResourceTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/IncludeResourceTransformer.groovy
@@ -21,9 +21,13 @@ package com.github.jengelman.gradle.plugins.shadow.transformers
 
 import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
-import org.gradle.api.file.FileTreeElement
 import org.codehaus.plexus.util.IOUtil
-
+import org.gradle.api.file.FileTreeElement
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 /**
  * A resource processor that allows the addition of an arbitrary file
  * content into the shaded JAR.
@@ -32,24 +36,33 @@ import org.codehaus.plexus.util.IOUtil
  *
  * @author John Engelman
  */
-public class IncludeResourceTransformer implements Transformer {
+class IncludeResourceTransformer implements Transformer {
     File file
 
+    @Optional
+    @PathSensitive(PathSensitivity.NONE)
+    @InputFile
+    File getFile() {
+        file?.exists() ? file : null
+    }
+
+    @Optional
+    @Input
     String resource
 
-    public boolean canTransformResource(FileTreeElement element) {
+    boolean canTransformResource(FileTreeElement element) {
         return false
     }
 
-    public void transform(TransformerContext context) {
+    void transform(TransformerContext context) {
         // no op
     }
 
-    public boolean hasTransformedResource() {
+    boolean hasTransformedResource() {
         return file != null ? file.exists() : false
     }
 
-    public void modifyOutputStream(ZipOutputStream os, boolean preserveFileTimestamps) {
+    void modifyOutputStream(ZipOutputStream os, boolean preserveFileTimestamps) {
         ZipEntry entry = new ZipEntry(resource)
         entry.time = TransformerContext.getEntryTimestamp(preserveFileTimestamps, entry.time)
         os.putNextEntry(entry)

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.groovy
@@ -23,9 +23,10 @@ import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
 import org.codehaus.plexus.util.IOUtil
 import org.gradle.api.file.FileTreeElement
+import org.gradle.api.tasks.Input
 
-import static java.nio.charset.StandardCharsets.*
-import static java.util.jar.JarFile.*
+import static java.nio.charset.StandardCharsets.UTF_8
+import static java.util.jar.JarFile.MANIFEST_NAME
 
 /**
  * A resource processor that can append arbitrary attributes to the first MANIFEST.MF
@@ -42,6 +43,7 @@ class ManifestAppenderTransformer implements Transformer {
     private byte[] manifestContents = []
     private final List<Tuple2<String, ? extends Comparable<?>>> attributes = []
 
+    @Input
     List<Tuple2<String, ? extends Comparable<?>>> getAttributes() { attributes }
 
     ManifestAppenderTransformer append(String name, Comparable<?> value) {

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformer.groovy
@@ -23,6 +23,8 @@ import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
 import org.gradle.api.file.FileTreeElement
 import org.codehaus.plexus.util.IOUtil
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 
 import static groovy.lang.Closure.IDENTITY
 
@@ -116,13 +118,20 @@ class PropertiesFileTransformer implements Transformer {
     private static final String PROPERTIES_SUFFIX = '.properties'
 
     // made public for testing
+    @Internal
     Map<String, Properties> propertiesEntries = [:]
 
     // Transformer properties
+    @Input
     List<String> paths = []
+    @Input
     Map<String, Map<String, String>> mappings = [:]
+    @Input
     String mergeStrategy = 'first' // latest, append
+    @Input
     String mergeSeparator = ','
+    // Gradle can't track the implementation for this closure
+    @Internal
     Closure<String> keyTransformer = IDENTITY
 
     @Override

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/XmlAppendingTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/XmlAppendingTransformer.groovy
@@ -23,6 +23,8 @@ import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
 import org.gradle.api.file.FileTreeElement
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
 import org.jdom2.Attribute
 import org.jdom2.Content
 import org.jdom2.Document
@@ -34,7 +36,6 @@ import org.jdom2.output.XMLOutputter
 import org.xml.sax.EntityResolver
 import org.xml.sax.InputSource
 import org.xml.sax.SAXException
-
 /**
  * Appends multiple occurrences of some XML file.
  * <p>
@@ -46,10 +47,14 @@ import org.xml.sax.SAXException
 class XmlAppendingTransformer implements Transformer {
     static final String XSI_NS = "http://www.w3.org/2001/XMLSchema-instance"
 
+    @Input
     boolean ignoreDtd = true
 
+    @Optional
+    @Input
     String resource
 
+    @Internal
     Document doc
 
     boolean canTransformResource(FileTreeElement element) {
@@ -111,10 +116,5 @@ class XmlAppendingTransformer implements Transformer {
         new XMLOutputter(Format.getPrettyFormat()).output(doc, os)
 
         doc = null
-    }
-
-    @Input
-    String getResource() {
-        return resource
     }
 }

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ApplicationSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ApplicationSpec.groovy
@@ -52,7 +52,7 @@ class ApplicationSpec extends PluginSpecification {
         settingsFile << "rootProject.name = 'myapp'"
 
         when:
-        BuildResult result = runner.withArguments('runShadow', '--stacktrace').build()
+        BuildResult result = run('runShadow', '--stacktrace')
 
         then: 'tests that runShadow executed and exited'
         assert result.output.contains('TestApp: Hello World! (foo)')
@@ -114,7 +114,7 @@ class ApplicationSpec extends PluginSpecification {
         settingsFile << "rootProject.name = 'myapp'"
 
         when:
-        runner.withArguments('shadowDistZip', '--stacktrace').build()
+        run('shadowDistZip', '--stacktrace')
 
         then: 'Check that the distribution zip was created'
         File zip = getFile('build/distributions/myapp-shadow-1.0.zip')
@@ -164,7 +164,7 @@ class ApplicationSpec extends PluginSpecification {
         settingsFile << "rootProject.name = 'myapp'"
 
         when:
-        runner.withArguments(ShadowApplicationPlugin.SHADOW_INSTALL_TASK_NAME).build()
+        run(ShadowApplicationPlugin.SHADOW_INSTALL_TASK_NAME)
 
         then: 'Check that the proper jar file was installed'
         File installedJar = getFile('build/install/myapp-shadow/lib/myapp-1.0-all.jar')

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ConfigurationCacheSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ConfigurationCacheSpec.groovy
@@ -49,8 +49,8 @@ class ConfigurationCacheSpec extends PluginSpecification {
         settingsFile << "rootProject.name = 'myapp'"
 
         when:
-        runner.withArguments('--configuration-cache', 'shadowJar').build()
-        def result = runner.withArguments('--configuration-cache', 'shadowJar').build()
+        run('--configuration-cache', 'shadowJar')
+        def result = run('--configuration-cache', 'shadowJar')
 
         then:
         result.output.contains("Reusing configuration cache.")
@@ -65,9 +65,9 @@ class ConfigurationCacheSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        runner.withArguments('--configuration-cache', 'shadowJar').build()
+        run('--configuration-cache', 'shadowJar')
         output.delete()
-        def result = runner.withArguments('--configuration-cache', 'shadowJar').build()
+        def result = run('--configuration-cache', 'shadowJar')
 
         then:
         contains(output, ['a.properties', 'b.properties'])
@@ -117,9 +117,9 @@ class ConfigurationCacheSpec extends PluginSpecification {
         def output = getFile('server/build/libs/server-all.jar')
 
         when:
-        runner.withArguments('--configuration-cache', 'shadowJar', '-s').build()
+        run('--configuration-cache', 'shadowJar', '-s')
         output.delete()
-        def result = runner.withArguments('--configuration-cache', 'shadowJar', '-s').build()
+        def result = run('--configuration-cache', 'shadowJar', '-s')
 
         then:
         output.exists()

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ConfigureShadowRelocationSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ConfigureShadowRelocationSpec.groovy
@@ -21,7 +21,7 @@ class ConfigureShadowRelocationSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        runner.withArguments('shadowJar', '-s').build()
+        run('shadowJar', '-s')
 
         then:
         then:

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/FilteringSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/FilteringSpec.groovy
@@ -4,7 +4,6 @@ import com.github.jengelman.gradle.plugins.shadow.util.PluginSpecification
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Ignore
-import spock.lang.IgnoreRest
 import spock.lang.Issue
 
 class FilteringSpec extends PluginSpecification {
@@ -29,7 +28,7 @@ class FilteringSpec extends PluginSpecification {
 
     def 'include all dependencies'() {
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         contains(output, ['a.properties', 'a2.properties', 'b.properties'])
@@ -46,7 +45,7 @@ class FilteringSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         contains(output, ['a.properties', 'b.properties'])
@@ -80,7 +79,7 @@ class FilteringSpec extends PluginSpecification {
         '''.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         contains(output, ['a.properties', 'a2.properties', 'b.properties', 'c.properties'])
@@ -115,7 +114,7 @@ class FilteringSpec extends PluginSpecification {
         '''.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         contains(output, ['a.properties', 'a2.properties', 'b.properties', 'c.properties'])
@@ -149,7 +148,7 @@ class FilteringSpec extends PluginSpecification {
         '''.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         contains(output, ['a.properties', 'a2.properties', 'b.properties', 'c.properties'])
@@ -161,7 +160,7 @@ class FilteringSpec extends PluginSpecification {
         buildFile.text = buildFile.text.replace('exclude(dependency(\'shadow:d:1.0\'))',
                                                 'exclude(dependency(\'shadow:c:1.0\'))')
 
-        BuildResult result = runner.withArguments('shadowJar').build()
+        BuildResult result = run('shadowJar')
 
         then:
         assert result.task(':shadowJar').outcome == TaskOutcome.SUCCESS
@@ -198,7 +197,7 @@ class FilteringSpec extends PluginSpecification {
         '''.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         contains(output, ['a.properties', 'a2.properties', 'b.properties', 'c.properties'])
@@ -213,7 +212,7 @@ class FilteringSpec extends PluginSpecification {
             }
         '''.stripIndent()
 
-        BuildResult result = runner.withArguments('shadowJar').build()
+        BuildResult result = run('shadowJar')
 
         then:
         assert result.task(':shadowJar').outcome == TaskOutcome.SUCCESS
@@ -253,7 +252,7 @@ class FilteringSpec extends PluginSpecification {
         '''.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         contains(output, ['d.properties', 'shadow/Passed.class'])
@@ -305,7 +304,7 @@ class FilteringSpec extends PluginSpecification {
         File serverOutput = getFile('server/build/libs/server-1.0-all.jar')
 
         when:
-        runner.withArguments(':server:shadowJar').build()
+        run(':server:shadowJar')
 
         then:
         serverOutput.exists()
@@ -359,7 +358,7 @@ class FilteringSpec extends PluginSpecification {
         File serverOutput = getFile('server/build/libs/server-1.0-all.jar')
 
         when:
-        runner.withArguments(':server:shadowJar').build()
+        run(':server:shadowJar')
 
         then:
         serverOutput.exists()
@@ -387,7 +386,7 @@ class FilteringSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         contains(output, ['a.properties', 'b.properties'])
@@ -421,7 +420,7 @@ class FilteringSpec extends PluginSpecification {
         '''.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         contains(output, ['a.properties', 'a2.properties', 'b.properties', 'c.properties'])

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/PublishingSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/PublishingSpec.groovy
@@ -32,13 +32,14 @@ class PublishingSpec extends PluginSpecification {
             apply plugin: 'maven'
 
             dependencies {
-               compile 'shadow:a:1.0'
+               implementation 'shadow:a:1.0'
                shadow 'shadow:b:1.0'
             }
             
             shadowJar {
-               baseName = 'maven-all'
-               classifier = null
+               archiveBaseName = 'maven-all'
+               archiveClassifier = null
+               archiveClassifier.convention(null)
             }
             
             uploadShadow {
@@ -51,7 +52,7 @@ class PublishingSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        run('uploadShadow')
+        runWithDeprecationWarnings('uploadShadow')
 
         then: 'Check that shadow artifact exists'
         File publishedFile = publishingRepo.rootDir.file('shadow/maven-all/1.0/maven-all-1.0.jar').canonicalFile
@@ -104,7 +105,7 @@ class PublishingSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        run('uploadShadow')
+        runWithDeprecationWarnings('uploadShadow')
 
         then: 'Check that shadow artifact exists'
         File publishedFile = publishingRepo.rootDir.file('shadow/maven/1.0/maven-1.0-all.jar').canonicalFile
@@ -140,13 +141,14 @@ class PublishingSpec extends PluginSpecification {
             mainClassName = 'my.App'
 
             dependencies {
-               compile 'shadow:a:1.0'
+               implementation 'shadow:a:1.0'
                shadow 'shadow:b:1.0'
             }
         """.stripIndent()
 
         when:
-        runWithDebug('install')
+        // The Maven plugin is deprecated
+        runWithDeprecationWarnings('install')
 
         then:
         noExceptionThrown()
@@ -167,13 +169,13 @@ class PublishingSpec extends PluginSpecification {
             apply plugin: 'maven-publish'
 
             dependencies {
-               compile 'shadow:a:1.0'
+               implementation 'shadow:a:1.0'
                shadow 'shadow:b:1.0'
             }
             
             shadowJar {
-               classifier = ''
-               baseName = 'maven-all'
+               archiveClassifier = ''
+               archiveBaseName = 'maven-all'
             }
             
             publishing {
@@ -269,13 +271,13 @@ class PublishingSpec extends PluginSpecification {
             }
             
             dependencies {
-                compile project(':a')
+                implementation project(':a')
                 shadow project(':b')
             }
 
             shadowJar {
-               classifier = ''
-               baseName = 'maven-all'
+               archiveClassifier = ''
+               archiveBaseName = 'maven-all'
             }
             
             publishing {
@@ -328,8 +330,8 @@ class PublishingSpec extends PluginSpecification {
         buildFile << """
             apply plugin: 'maven-publish'
             dependencies {
-               compile 'shadow:a:1.0'
-               compile 'shadow:b:1.0'
+               implementation 'shadow:a:1.0'
+               implementation 'shadow:b:1.0'
                shadow 'shadow:b:1.0'
             }
             group = 'com.acme'
@@ -391,14 +393,13 @@ class PublishingSpec extends PluginSpecification {
         def apiVariant = gmmContents.variants.find { it.name == 'apiElements' }
         apiVariant.attributes[Usage.USAGE_ATTRIBUTE.name] == Usage.JAVA_API
         apiVariant.attributes[Bundling.BUNDLING_ATTRIBUTE.name] == Bundling.EXTERNAL
-        apiVariant.dependencies.size() == 2
-        apiVariant.dependencies.module as Set == ['a', 'b'] as Set
+        !apiVariant.dependencies
 
         def runtimeVariant = gmmContents.variants.find { it.name == 'runtimeElements' }
         runtimeVariant.attributes[Usage.USAGE_ATTRIBUTE.name] == Usage.JAVA_RUNTIME
         runtimeVariant.attributes[Bundling.BUNDLING_ATTRIBUTE.name] == Bundling.EXTERNAL
         runtimeVariant.dependencies.size() == 2
-        apiVariant.dependencies.module as Set == ['a', 'b'] as Set
+        runtimeVariant.dependencies.module as Set == ['a', 'b'] as Set
 
         def shadowRuntimeVariant = gmmContents.variants.find { it.name == 'shadowRuntimeElements' }
         shadowRuntimeVariant.attributes[Usage.USAGE_ATTRIBUTE.name] == Usage.JAVA_RUNTIME

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/PublishingSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/PublishingSpec.groovy
@@ -51,7 +51,7 @@ class PublishingSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        runner.withArguments('uploadShadow').build()
+        run('uploadShadow')
 
         then: 'Check that shadow artifact exists'
         File publishedFile = publishingRepo.rootDir.file('shadow/maven-all/1.0/maven-all-1.0.jar').canonicalFile
@@ -104,7 +104,7 @@ class PublishingSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        runner.withArguments('uploadShadow').build()
+        run('uploadShadow')
 
         then: 'Check that shadow artifact exists'
         File publishedFile = publishingRepo.rootDir.file('shadow/maven/1.0/maven-1.0-all.jar').canonicalFile
@@ -146,7 +146,7 @@ class PublishingSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        runner.withArguments('install').withDebug(true).build()
+        runWithDebug('install')
 
         then:
         noExceptionThrown()
@@ -192,7 +192,7 @@ class PublishingSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        runner.withArguments('publish').build()
+        run('publish')
 
         then:
         File publishedFile = publishingRepo.rootDir.file('shadow/maven-all/1.0/maven-all-1.0.jar').canonicalFile
@@ -289,7 +289,7 @@ class PublishingSpec extends PluginSpecification {
         """.stripMargin()
 
         when:
-        runner.withArguments('publish').build()
+        run('publish')
 
         then:
         File publishedFile = publishingRepo.rootDir.file('shadow/maven-all/1.0/maven-all-1.0.jar').canonicalFile
@@ -349,7 +349,7 @@ class PublishingSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        runner.withArguments('publish').build()
+        run('publish')
 
         then:
         File mainJar = publishingRepo.rootDir.file('com/acme/maven/1.0/maven-1.0.jar').canonicalFile

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/RelocationSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/RelocationSpec.groovy
@@ -27,7 +27,7 @@ class RelocationSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         contains(output, [
@@ -95,7 +95,7 @@ class RelocationSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         contains(output, [
@@ -158,7 +158,7 @@ class RelocationSpec extends PluginSpecification {
         '''.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         contains(output, [
@@ -230,7 +230,7 @@ class RelocationSpec extends PluginSpecification {
         '''.stripIndent()
 
         when:
-        runner.withArguments(':app:shadowJar').build()
+        run(':app:shadowJar')
 
         then:
         File appOutput = getFile('app/build/libs/app-all.jar')
@@ -271,7 +271,7 @@ class RelocationSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         contains(output, [
@@ -316,7 +316,7 @@ class RelocationSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         noExceptionThrown()

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowPluginSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowPluginSpec.groovy
@@ -140,13 +140,14 @@ class ShadowPluginSpec extends PluginSpecification {
         '''.stripIndent()
 
         buildFile << """
-            dependencies { compile 'junit:junit:3.8.2' }
+            dependencies { implementation 'junit:junit:3.8.2' }
 
             // tag::rename[]
             shadowJar {
-               baseName = 'shadow'
-               classifier = null
-               version = null
+               archiveBaseName = 'shadow'
+               archiveClassifier = null
+               archiveVersion = null
+               archiveVersion.convention(null)
             }
             // end::rename[]
         """.stripIndent()

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowPluginSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowPluginSpec.groovy
@@ -126,7 +126,7 @@ class ShadowPluginSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         assert output.exists()
@@ -152,7 +152,7 @@ class ShadowPluginSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         contains(output("shadow.jar"), ['shadow/Passed.class', 'junit/framework/Test.class'])
@@ -198,7 +198,7 @@ class ShadowPluginSpec extends PluginSpecification {
         File serverOutput = getFile('server/build/libs/server-all.jar')
 
         when:
-        runner.withArguments(':server:shadowJar').build()
+        run(':server:shadowJar')
 
         then:
         serverOutput.exists()
@@ -255,7 +255,7 @@ class ShadowPluginSpec extends PluginSpecification {
         File serverOutput = getFile('server/build/libs/server-all.jar')
 
         when:
-        runner.withArguments(':server:shadowJar', '--stacktrace').withDebug(true).build()
+        runWithDebug(':server:shadowJar', '--stacktrace')
 
         then:
         serverOutput.exists()
@@ -310,7 +310,7 @@ class ShadowPluginSpec extends PluginSpecification {
         File serverOutput = getFile('server/build/libs/server-all.jar')
 
         when:
-        runner.withArguments(':server:shadowJar', '--stacktrace').withDebug(true).build()
+        runWithDebug(':server:shadowJar', '--stacktrace')
 
         then:
         serverOutput.exists()
@@ -363,7 +363,7 @@ class ShadowPluginSpec extends PluginSpecification {
         File serverOutput = file('server/build/libs/server-all.jar')
 
         when:
-        runner.withArguments(':server:shadowJar', '--stacktrace').withDebug(true).build()
+        runWithDebug(':server:shadowJar', '--stacktrace')
 
         then:
         contains(serverOutput, [
@@ -418,7 +418,7 @@ class ShadowPluginSpec extends PluginSpecification {
         File serverOutput = file('server/build/libs/server-all.jar')
 
         when:
-        runner.withArguments(':server:shadowJar', '--stacktrace').withDebug(true).build()
+        runWithDebug(':server:shadowJar', '--stacktrace')
 
         then:
         contains(serverOutput, [
@@ -471,7 +471,7 @@ class ShadowPluginSpec extends PluginSpecification {
         File serverOutput = file('server/build/libs/server-all.jar')
 
         when:
-        runner.withArguments(':server:shadowJar', '--stacktrace').withDebug(true).build()
+        runWithDebug(':server:shadowJar', '--stacktrace')
 
         then:
         contains(serverOutput, [
@@ -549,7 +549,7 @@ class ShadowPluginSpec extends PluginSpecification {
         File serverOutput = getFile('impl/build/libs/impl-all.jar')
 
         when:
-        runner.withArguments(':impl:shadowJar', '--stacktrace').withDebug(true).build()
+        runWithDebug(':impl:shadowJar', '--stacktrace')
 
         then:
         serverOutput.exists()
@@ -625,7 +625,7 @@ class ShadowPluginSpec extends PluginSpecification {
         File serverOutput = getFile('impl/build/libs/impl-all.jar')
 
         when:
-        runner.withArguments(':impl:shadowJar', '--stacktrace').withDebug(true).build()
+        runWithDebug(':impl:shadowJar', '--stacktrace')
 
         then:
         serverOutput.exists()
@@ -679,7 +679,7 @@ class ShadowPluginSpec extends PluginSpecification {
         File serverOutput = getFile('server/build/libs/server.jar')
 
         when:
-        runner.withArguments(':server:jar').build()
+        run(':server:jar')
 
         then:
         serverOutput.exists()
@@ -737,7 +737,7 @@ class ShadowPluginSpec extends PluginSpecification {
         File serverOutput = getFile('server/build/libs/server-all.jar')
 
         when:
-        runner.withArguments(':server:shadowJar').build()
+        run(':server:shadowJar')
 
         then:
         serverOutput.exists()
@@ -774,7 +774,7 @@ class ShadowPluginSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         contains(output, ['a.properties', 'META-INF/a.properties'])
@@ -801,7 +801,7 @@ class ShadowPluginSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         contains(output, ['a.properties'])
@@ -878,7 +878,7 @@ class ShadowPluginSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         contains(output, ['a.properties'])
@@ -905,7 +905,7 @@ class ShadowPluginSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         JarFile jar = new JarFile(output)
@@ -920,7 +920,7 @@ class ShadowPluginSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         assert output.exists()
@@ -952,7 +952,7 @@ class ShadowPluginSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         assert output.exists()
@@ -974,7 +974,7 @@ class ShadowPluginSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         assert output.exists()
@@ -1001,7 +1001,7 @@ class ShadowPluginSpec extends PluginSpecification {
         """
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         assert output.exists()
@@ -1021,7 +1021,7 @@ class ShadowPluginSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        runner.withArguments('shadowJar', '--stacktrace').build()
+        run('shadowJar', '--stacktrace')
 
         then:
         assert output.exists()
@@ -1069,7 +1069,7 @@ class ShadowPluginSpec extends PluginSpecification {
         File serverOutput = getFile('impl/build/libs/impl-1.0-all.jar')
 
         when:
-        runner.withArguments(':impl:shadowJar', '--stacktrace').withDebug(true).build()
+        runWithDebug(':impl:shadowJar', '--stacktrace')
 
         then:
         serverOutput.exists()
@@ -1141,7 +1141,7 @@ class ShadowPluginSpec extends PluginSpecification {
         settingsFile << "rootProject.name = 'myapp'"
 
         when:
-        BuildResult result = runner.withArguments('runShadow', '--stacktrace').build()
+        BuildResult result = run('runShadow', '--stacktrace')
 
         then: 'tests that runShadow executed and exited'
         assert result.output.contains('TestApp: Hello World! (foo)')
@@ -1199,7 +1199,7 @@ class ShadowPluginSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        BuildResult result = runner.withArguments('runShadow', '--stacktrace').build()
+        BuildResult result = run('runShadow', '--stacktrace')
 
         then: 'tests that runShadow executed and exited'
         assert result.output.contains('TestApp: Hello World! (foo)')
@@ -1241,7 +1241,7 @@ class ShadowPluginSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        BuildResult result = runner.withArguments('runShadow', '--stacktrace').build()
+        BuildResult result = run('runShadow', '--stacktrace')
 
         then: 'tests that runShadow executed and exited'
         assert result.output.contains('TestApp: Hello World! (foo)')

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/TransformerSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/TransformerSpec.groovy
@@ -40,7 +40,7 @@ class TransformerSpec extends PluginSpecification {
         """.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         assert output.exists()
@@ -80,7 +80,7 @@ two # NOTE: No newline terminates this line/file'''.stripIndent()
         """.stripIndent()
 
         when:
-            runner.withArguments('shadowJar').build()
+            run('shadowJar')
 
         then:
             assert output.exists()
@@ -120,7 +120,7 @@ two # NOTE: No newline terminates this line/file'''.stripIndent()
         """.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         assert output.exists()
@@ -175,7 +175,7 @@ com.mysql.jdbc.Driver'''.stripIndent())
         """.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         assert output.exists()
@@ -223,7 +223,7 @@ org.mortbay.log.Factory'''.stripIndent()
         """.stripIndent()
 
         when:
-            runner.withArguments('shadowJar').build()
+            run('shadowJar')
 
         then:
             assert output.exists()
@@ -260,7 +260,7 @@ two # NOTE: No newline terminates this line/file'''.stripIndent()
                 'three # NOTE: No newline terminates this line/file'
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         assert output.exists()
@@ -296,7 +296,7 @@ two # NOTE: No newline terminates this line/file'''.stripIndent()
         """.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         assert output.exists()
@@ -329,7 +329,7 @@ two # NOTE: No newline terminates this line/file
         """.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         assert output.exists()
@@ -365,7 +365,7 @@ two # NOTE: No newline terminates this line/file
         """.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         assert output.exists()
@@ -409,7 +409,7 @@ two # NOTE: No newline terminates this line/file
         """.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         assert output.exists()
@@ -461,7 +461,7 @@ two # NOTE: No newline terminates this line/file
         """.stripIndent()
 
         when:
-        runner.withArguments('shadowJar').build()
+        run('shadowJar')
 
         then:
         assert output.exists()
@@ -508,7 +508,7 @@ two # NOTE: No newline terminates this line/file
         """.stripIndent()
 
         when:
-        runner.withArguments('jar', 'shadowJar').build()
+        run('jar', 'shadowJar')
 
         then:
         File jar = getFile('build/libs/shadow-1.0.jar')
@@ -568,7 +568,7 @@ two # NOTE: No newline terminates this line/file
         """.stripIndent()
 
         when:
-        runner.withArguments('jar', 'shadowJar').build()
+        run('jar', 'shadowJar')
 
         then:
         File jar = getFile('build/libs/shadow-1.0.jar')
@@ -627,7 +627,7 @@ staticExtensionClasses=com.acme.bar.SomeStaticExtension'''.stripIndent()).write(
             """.stripIndent()
 
         when:
-            runner.withArguments('shadowJar').build()
+            run('shadowJar')
 
         then:
             assert output.exists()
@@ -669,7 +669,7 @@ staticExtensionClasses=com.acme.bar.SomeStaticExtension'''.stripIndent()).write(
             """.stripIndent()
 
         when:
-            runner.withArguments('shadowJar').build()
+            run('shadowJar')
 
         then:
             assert output.exists()

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/AbstractCachingSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/AbstractCachingSpec.groovy
@@ -20,7 +20,7 @@ abstract class AbstractCachingSpec extends PluginSpecification {
         // test and we won't accidentally use cached outputs from a different test or a different build.
         settingsFile << """
             buildCache {
-                local(DirectoryBuildCache) {
+                local {
                     directory = new File(rootDir, 'build-cache')
                 }
             }

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/AbstractCachingSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/AbstractCachingSpec.groovy
@@ -35,7 +35,7 @@ abstract class AbstractCachingSpec extends PluginSpecification {
     BuildResult runWithCacheEnabled(String... arguments) {
         List<String> cacheArguments = [ '--build-cache' ]
         cacheArguments.addAll(arguments)
-        return runner(cacheArguments).build()
+        return run(cacheArguments)
     }
 
     BuildResult runInAlternateDirWithCacheEnabled(String... arguments) {
@@ -58,12 +58,6 @@ abstract class AbstractCachingSpec extends PluginSpecification {
     void assertShadowJarHasResult(TaskOutcome expectedOutcome) {
         def result = runWithCacheEnabled(shadowJarTask)
         assert result.task(shadowJarTask).outcome == expectedOutcome
-        assert !containsDeprecationWarning(result.output)
-    }
-
-    boolean containsDeprecationWarning(String output) {
-        output.contains("has been deprecated and is scheduled to be removed in Gradle") ||
-                output.contains("has been deprecated. This is scheduled to be removed in Gradle")
     }
 
     void assertShadowJarHasResultInAlternateDir(TaskOutcome expectedOutcome) {

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/AbstractCachingSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/AbstractCachingSpec.groovy
@@ -12,7 +12,7 @@ import static org.gradle.testkit.runner.TaskOutcome.FROM_CACHE
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 
-class AbstractCachingSpec extends PluginSpecification {
+abstract class AbstractCachingSpec extends PluginSpecification {
     @Rule TemporaryFolder alternateDir
 
     def setup() {
@@ -35,7 +35,7 @@ class AbstractCachingSpec extends PluginSpecification {
     BuildResult runWithCacheEnabled(String... arguments) {
         List<String> cacheArguments = [ '--build-cache' ]
         cacheArguments.addAll(arguments)
-        return runner.withArguments(cacheArguments).build()
+        return runner(cacheArguments).build()
     }
 
     BuildResult runInAlternateDirWithCacheEnabled(String... arguments) {
@@ -58,6 +58,12 @@ class AbstractCachingSpec extends PluginSpecification {
     void assertShadowJarHasResult(TaskOutcome expectedOutcome) {
         def result = runWithCacheEnabled(shadowJarTask)
         assert result.task(shadowJarTask).outcome == expectedOutcome
+        assert !containsDeprecationWarning(result.output)
+    }
+
+    boolean containsDeprecationWarning(String output) {
+        output.contains("has been deprecated and is scheduled to be removed in Gradle") ||
+                output.contains("has been deprecated. This is scheduled to be removed in Gradle")
     }
 
     void assertShadowJarHasResultInAlternateDir(TaskOutcome expectedOutcome) {

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/ShadowJarCachingSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/ShadowJarCachingSpec.groovy
@@ -65,7 +65,7 @@ class ShadowJarCachingSpec extends AbstractCachingSpec {
         when:
         changeConfigurationTo """
             shadowJar {
-                baseName = "foo"
+                archiveBaseName = "foo"
                 from('${artifact.path}')
                 from('${project.path}')
             }

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/PluginSpecification.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/PluginSpecification.groovy
@@ -3,6 +3,7 @@ package com.github.jengelman.gradle.plugins.shadow.util
 import com.github.jengelman.gradle.plugins.shadow.util.file.TestFile
 import com.google.common.base.StandardSystemProperty
 import org.codehaus.plexus.util.IOUtil
+import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -59,12 +60,33 @@ class PluginSpecification extends Specification {
                 .withPluginClasspath()
     }
 
-    GradleRunner runner(String... tasks) {
-        runner(tasks.toList())
+    BuildResult run(String... tasks) {
+        run(tasks.toList())
+    }
+
+    BuildResult run(List<String> tasks) {
+        def result = runner(tasks).build()
+        assertNoDeprecationWarnings(result)
+        return result
+    }
+
+    BuildResult runWithDebug(String... tasks) {
+        def result = runner(tasks.toList()).withDebug(true).build()
+        assertNoDeprecationWarnings(result)
+        return result
     }
 
     GradleRunner runner(Collection<String> tasks) {
         runner.withArguments(["-Dorg.gradle.warning.mode=all"] + tasks.toList())
+    }
+
+    boolean containsDeprecationWarning(BuildResult result) {
+        result.output.contains("has been deprecated and is scheduled to be removed in Gradle") ||
+                result.output.contains("has been deprecated. This is scheduled to be removed in Gradle")
+    }
+
+    void assertNoDeprecationWarnings(BuildResult result) {
+//        assert !containsDeprecationWarning(result)
     }
 
     File getLocalRepo() {

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/PluginSpecification.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/PluginSpecification.groovy
@@ -59,6 +59,14 @@ class PluginSpecification extends Specification {
                 .withPluginClasspath()
     }
 
+    GradleRunner runner(String... tasks) {
+        runner(tasks.toList())
+    }
+
+    GradleRunner runner(Collection<String> tasks) {
+        runner.withArguments(["-Dorg.gradle.warning.mode=all"] + tasks.toList())
+    }
+
     File getLocalRepo() {
         def rootRelative = new File("build/localrepo")
         rootRelative.directory ? rootRelative : new File(new File(StandardSystemProperty.USER_DIR.value()).parentFile, "build/localrepo")

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/PluginSpecification.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/PluginSpecification.groovy
@@ -64,6 +64,11 @@ class PluginSpecification extends Specification {
         run(tasks.toList())
     }
 
+    BuildResult runWithDeprecationWarnings(String... tasks) {
+        def result = runner(tasks.toList()).build()
+        return result
+    }
+
     BuildResult run(List<String> tasks) {
         def result = runner(tasks).build()
         assertNoDeprecationWarnings(result)

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/PluginSpecification.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/PluginSpecification.groovy
@@ -86,7 +86,7 @@ class PluginSpecification extends Specification {
     }
 
     void assertNoDeprecationWarnings(BuildResult result) {
-//        assert !containsDeprecationWarning(result)
+        assert !containsDeprecationWarning(result)
     }
 
     File getLocalRepo() {


### PR DESCRIPTION
so that the transformer remain compatible with Gradle 7.0.
In Gradle 7.0 missing annotations on input properties will fail the build. Input properties include properties on `@Nested` inputs, which includes all the `Transformers`.