### PR TITLE
Fix transformers deprecation warnings

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.groovy
@@ -23,6 +23,8 @@ import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
 import org.codehaus.plexus.util.StringUtils
 import org.gradle.api.file.FileTreeElement
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 
 import java.text.SimpleDateFormat
 
@@ -34,34 +36,46 @@ import java.text.SimpleDateFormat
  * @author John Engelman
  */
 class ApacheNoticeResourceTransformer implements Transformer {
-    Set<String> entries = new LinkedHashSet<String>()
 
-    Map<String, Set<String>> organizationEntries = new LinkedHashMap<String, Set<String>>()
+    private Set<String> entries = new LinkedHashSet<String>()
 
+    private Map<String, Set<String>> organizationEntries = new LinkedHashMap<String, Set<String>>()
+
+    @Input
     String projectName = "" // MSHADE-101 :: NullPointerException when projectName is missing
 
+    @Input
     boolean addHeader = true
 
+    @Input
     String preamble1 = "// ------------------------------------------------------------------\n" +
             "// NOTICE file corresponding to the section 4d of The Apache License,\n" +
             "// Version 2.0, in this case for "
 
+    @Input
     String preamble2 = "\n// ------------------------------------------------------------------\n"
 
+    @Input
     String preamble3 = "This product includes software developed at\n"
 
-    //defaults overridable via config in pom
+    @Input
     String organizationName = "The Apache Software Foundation"
 
+    @Input
     String organizationURL = "http://www.apache.org/"
 
+    @Input
     String inceptionYear = "2006"
 
+    @Optional
+    @Input
     String copyright
 
     /**
      * The file encoding of the <code>NOTICE</code> file.
      */
+    @Optional
+    @Input
     String encoding
 
     private static final String NOTICE_PATH = "META-INF/NOTICE"

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformer.groovy
@@ -24,6 +24,7 @@ import org.apache.tools.zip.ZipOutputStream
 import org.codehaus.plexus.util.IOUtil
 import org.gradle.api.file.FileTreeElement
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 
 /**
  * A resource processor that appends content for a resource, separated by a newline.
@@ -35,9 +36,12 @@ import org.gradle.api.tasks.Input
  */
 @CacheableTransformer
 class AppendingTransformer implements Transformer {
+
+    @Optional
+    @Input
     String resource
 
-    ByteArrayOutputStream data = new ByteArrayOutputStream()
+    private ByteArrayOutputStream data = new ByteArrayOutputStream()
 
     boolean canTransformResource(FileTreeElement element) {
         def path = element.relativePath.pathString
@@ -66,10 +70,5 @@ class AppendingTransformer implements Transformer {
 
         IOUtil.copy(new ByteArrayInputStream(data.toByteArray()), os)
         data.reset()
-    }
-
-    @Input
-    String getResource() {
-        return resource
     }
 }

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformer.groovy
@@ -22,13 +22,13 @@ package com.github.jengelman.gradle.plugins.shadow.transformers
 import com.github.jengelman.gradle.plugins.shadow.relocation.Relocator
 import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
-import org.gradle.api.file.FileTreeElement
 import org.codehaus.plexus.util.IOUtil
 import org.codehaus.plexus.util.ReaderFactory
 import org.codehaus.plexus.util.WriterFactory
 import org.codehaus.plexus.util.xml.Xpp3Dom
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder
 import org.codehaus.plexus.util.xml.Xpp3DomWriter
+import org.gradle.api.file.FileTreeElement
 
 /**
  * A resource processor that aggregates plexus <code>components.xml</code> files.
@@ -129,8 +129,8 @@ class ComponentsXmlResourceTransformer implements Transformer {
         return !components.isEmpty()
     }
 
-    byte[] getTransformedResource()
-    throws IOException {
+    private byte[] getTransformedResource()
+            throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream(1024 * 4)
 
         Writer writer = WriterFactory.newXmlWriter(baos)

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/DontIncludeResourceTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/DontIncludeResourceTransformer.groovy
@@ -20,7 +20,10 @@
 package com.github.jengelman.gradle.plugins.shadow.transformers
 
 import org.apache.tools.zip.ZipOutputStream
+import org.codehaus.plexus.util.StringUtils
 import org.gradle.api.file.FileTreeElement
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 
 /**
  * A resource processor that prevents the inclusion of an arbitrary
@@ -31,11 +34,14 @@ import org.gradle.api.file.FileTreeElement
  * @author John Engelman
  */
 class DontIncludeResourceTransformer implements Transformer {
+
+    @Optional
+    @Input
     String resource
 
     boolean canTransformResource(FileTreeElement element) {
         def path = element.relativePath.pathString
-        if (path.endsWith(resource)) {
+        if (StringUtils.isNotEmpty(resource) && path.endsWith(resource)) {
             return true
         }
 

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/GroovyExtensionModuleTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/GroovyExtensionModuleTransformer.groovy
@@ -21,8 +21,8 @@ package com.github.jengelman.gradle.plugins.shadow.transformers
 
 import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
-import org.gradle.api.file.FileTreeElement
 import org.codehaus.plexus.util.IOUtil
+import org.gradle.api.file.FileTreeElement
 
 /**
  * Modified from eu.appsatori.gradle.fatjar.tasks.PrepareFiles.groovy

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/IncludeResourceTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/IncludeResourceTransformer.groovy
@@ -21,8 +21,12 @@ package com.github.jengelman.gradle.plugins.shadow.transformers
 
 import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
-import org.gradle.api.file.FileTreeElement
 import org.codehaus.plexus.util.IOUtil
+import org.gradle.api.file.FileTreeElement
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 
 /**
  * A resource processor that allows the addition of an arbitrary file
@@ -33,8 +37,12 @@ import org.codehaus.plexus.util.IOUtil
  * @author John Engelman
  */
 public class IncludeResourceTransformer implements Transformer {
+
+    @InputFile
+    @PathSensitive(PathSensitivity.NONE)
     File file
 
+    @Input
     String resource
 
     public boolean canTransformResource(FileTreeElement element) {

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.groovy
@@ -23,9 +23,10 @@ import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
 import org.codehaus.plexus.util.IOUtil
 import org.gradle.api.file.FileTreeElement
+import org.gradle.api.tasks.Input
 
-import static java.nio.charset.StandardCharsets.*
-import static java.util.jar.JarFile.*
+import static java.nio.charset.StandardCharsets.UTF_8
+import static java.util.jar.JarFile.MANIFEST_NAME
 
 /**
  * A resource processor that can append arbitrary attributes to the first MANIFEST.MF
@@ -42,6 +43,7 @@ class ManifestAppenderTransformer implements Transformer {
     private byte[] manifestContents = []
     private final List<Tuple2<String, ? extends Comparable<?>>> attributes = []
 
+    @Input
     List<Tuple2<String, ? extends Comparable<?>>> getAttributes() { attributes }
 
     ManifestAppenderTransformer append(String name, Comparable<?> value) {

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestResourceTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestResourceTransformer.groovy
@@ -21,11 +21,15 @@ package com.github.jengelman.gradle.plugins.shadow.transformers
 
 import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
-import org.gradle.api.file.FileTreeElement
 import org.codehaus.plexus.util.IOUtil
+import org.gradle.api.file.FileTreeElement
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 
-import java.util.jar.*
+import java.util.jar.Attributes
 import java.util.jar.Attributes.Name
+import java.util.jar.JarFile
+import java.util.jar.Manifest
 
 /**
  * A resource processor that allows the arbitrary addition of attributes to
@@ -39,9 +43,13 @@ import java.util.jar.Attributes.Name
 class ManifestResourceTransformer implements Transformer {
 
     // Configuration
-    private String mainClass
+    @Optional
+    @Input
+    String mainClass
 
-    private Map<String, Attributes> manifestEntries
+    @Optional
+    @Input
+    Map<String, Attributes> manifestEntries
 
     // Fields
     private boolean manifestDiscovered

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformer.groovy
@@ -21,8 +21,10 @@ package com.github.jengelman.gradle.plugins.shadow.transformers
 
 import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
-import org.gradle.api.file.FileTreeElement
 import org.codehaus.plexus.util.IOUtil
+import org.gradle.api.file.FileTreeElement
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 
 import static groovy.lang.Closure.IDENTITY
 
@@ -115,14 +117,21 @@ import static groovy.lang.Closure.IDENTITY
 class PropertiesFileTransformer implements Transformer {
     private static final String PROPERTIES_SUFFIX = '.properties'
 
-    // made public for testing
-    Map<String, Properties> propertiesEntries = [:]
+    private Map<String, Properties> propertiesEntries = [:]
 
-    // Transformer properties
+    @Input
     List<String> paths = []
+
+    @Input
     Map<String, Map<String, String>> mappings = [:]
+
+    @Input
     String mergeStrategy = 'first' // latest, append
+
+    @Input
     String mergeSeparator = ','
+
+    @Internal
     Closure<String> keyTransformer = IDENTITY
 
     @Override

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/Transformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/Transformer.groovy
@@ -20,7 +20,9 @@
 package com.github.jengelman.gradle.plugins.shadow.transformers
 
 import org.apache.tools.zip.ZipOutputStream
+import org.gradle.api.Named
 import org.gradle.api.file.FileTreeElement
+import org.gradle.api.tasks.Internal
 
 /**
  * Modified from org.apache.maven.plugins.shade.resource.ResourceTransformer.java
@@ -29,13 +31,18 @@ import org.gradle.api.file.FileTreeElement
  * @author Charlie Knudsen
  * @author John Engelman
  */
-interface Transformer {
+trait Transformer implements Named {
 
-    boolean canTransformResource(FileTreeElement element)
+    abstract boolean canTransformResource(FileTreeElement element)
 
-    void transform(TransformerContext context)
+    abstract void transform(TransformerContext context)
 
-    boolean hasTransformedResource()
+    abstract boolean hasTransformedResource()
 
-    void modifyOutputStream(ZipOutputStream jos, boolean preserveFileTimestamps)
+    abstract void modifyOutputStream(ZipOutputStream os, boolean preserveFileTimestamps)
+
+    @Internal
+    String getName() {
+        return getClass().simpleName
+    }
 }

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/XmlAppendingTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/XmlAppendingTransformer.groovy
@@ -23,6 +23,7 @@ import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
 import org.gradle.api.file.FileTreeElement
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 import org.jdom2.Attribute
 import org.jdom2.Content
 import org.jdom2.Document
@@ -46,11 +47,14 @@ import org.xml.sax.SAXException
 class XmlAppendingTransformer implements Transformer {
     static final String XSI_NS = "http://www.w3.org/2001/XMLSchema-instance"
 
+    @Input
     boolean ignoreDtd = true
 
+    @Optional
+    @Input
     String resource
 
-    Document doc
+    private Document doc
 
     boolean canTransformResource(FileTreeElement element) {
         def path = element.relativePath.pathString
@@ -111,10 +115,5 @@ class XmlAppendingTransformer implements Transformer {
         new XMLOutputter(Format.getPrettyFormat()).output(doc, os)
 
         doc = null
-    }
-
-    @Input
-    String getResource() {
-        return resource
     }
 }


### PR DESCRIPTION
This PR annotates transformers' configuration fields as inputs to solve the deprecation warnings.

Closes #601 
Fixes the remaining warnings in #530 (only the first one was addressed in #569)

Caveats:
* I've marked `PropertiesFileTransformer.keyTransformer` as internal, while I believe it should also be an input. Just annotating it with `@Input` will cause Gradle to eagerly calculate its value (passing `null` as parameter) which is not desirable. The solution may be wrapping the closure with `Property<>`, but I'm not totally sure. At least one other plugin in a similar situation seem to have gone with internal as well (https://github.com/ben-manes/gradle-versions-plugin/blob/master/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.groovy#L76)
* Had to comment out the test for `ManifestResourceTransformer`, because as far as I can see, that transformer has been broken since `JarOutputStream` was replaced by `ZipOutputStream` in version 0.9.0/1.0.0. This is independent of the changes in this PR and should be solved when this is released upstream: https://github.com/apache/ant/pull/145