### PR TITLE
Use protected superclass fields via super because of GROOVY-9292

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.groovy
@@ -107,7 +107,7 @@ class ServiceFileTransformer implements Transformer, PatternFilterable {
         }
 
         public void append( InputStream is ) throws IOException {
-            if ( count > 0 && buf[count - 1] != '\n' && buf[count - 1] != '\r' ) {
+            if ( super.count > 0 && super.buf[super.count - 1] != '\n' && super.buf[super.count - 1] != '\r' ) {
                 byte[] newline = '\n'.bytes
                 write(newline, 0, newline.length)
             }
@@ -115,7 +115,7 @@ class ServiceFileTransformer implements Transformer, PatternFilterable {
         }
 
         public InputStream toInputStream() {
-            return new ByteArrayInputStream( buf, 0, count )
+            return new ByteArrayInputStream( super.buf, 0, super.count )
         }
     }
 


### PR DESCRIPTION
The use of the abstract fields in the ServiceFileTransformer without super results in an error in newer Groovy versions since [PR 1050](https://github.com/apache/groovy/pull/1050). For the current Gradle 7.0 RC, that looks like this:
```
Caused by: groovy.lang.MissingPropertyException: No such property: count for class: com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer
        at com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer$ServiceStream.append(ServiceFileTransformer.groovy:110)
        at ...
```
Apart from that, the plugin is usable with Gradle 7.0, as far as I can tell.