### PR TITLE
Fix #648

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation 'org.apache.ant:ant:1.9.7'
     implementation 'org.codehaus.plexus:plexus-utils:3.0.24'
     implementation "org.apache.logging.log4j:log4j-core:2.13.3"
-    implementation('org.vafer:jdependency:2.1.1') {
+    implementation('org.vafer:jdependency:2.6.0') {
         exclude group: 'org.ow2.asm'
     }
 


### PR DESCRIPTION
jdependency 2.1.1 shadows asm without relocating it, causing conflicts with dependencies that require modern versions of asm, this PR updates jdependency to an updated version that relocated it correctly.

See https://github.com/tcurdt/jdependency/commit/6e233125c48a0a977f9d443b154180b7341ecc2a