### PR TITLE
Remove imports of old maven plugin classes for Gradle 7.0 build compat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocatio
 
 buildscript {
     repositories {
-        jcenter()
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
+        gradlePluginPortal()
     }
     dependencies {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.1'
@@ -59,7 +56,7 @@ apply from: file('gradle/ghPages.gradle')
 apply from: file('gradle/dependencies.gradle')
 
 repositories {
-    jcenter()
+    gradlePluginPortal()
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
 
 task downloadDependencies(type: Exec) {
-    dependsOn configurations.testRuntime
+    dependsOn configurations.testRuntimeClasspath
     commandLine 'echo', 'Downloaded all dependencies'
 }
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -3,7 +3,7 @@ import org.codehaus.groovy.control.CompilerConfiguration
 apply plugin: 'groovy'
 
 repositories {
-    jcenter()
+    gradlePluginPortal()
 }
 
 ScriptHolder holder = new ScriptHolder()

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.groovy
@@ -4,14 +4,11 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.maven.Conf2ScopeMappingContainer
-import org.gradle.api.artifacts.maven.MavenPom
 import org.gradle.api.attributes.Bundling
 import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.attributes.Usage
 import org.gradle.api.plugins.JavaPluginConvention
-import org.gradle.api.plugins.MavenPlugin
 import org.gradle.api.tasks.Upload
 import org.gradle.configuration.project.ProjectConfigurationActionContainer
 import org.gradle.util.GradleVersion
@@ -104,14 +101,16 @@ class ShadowJavaPlugin implements Plugin<Project> {
                             return
                         }
                         upload.configuration = project.configurations.shadow
-                        MavenPom pom = upload.repositories.mavenDeployer.pom
+                        def pom = upload.repositories.mavenDeployer.pom
                         if (project.configurations.findByName("api")) {
                             pom.scopeMappings.mappings.remove(project.configurations.api)
                         }
                         pom.scopeMappings.mappings.remove(project.configurations.compile)
                         pom.scopeMappings.mappings.remove(project.configurations.implementation)
                         pom.scopeMappings.mappings.remove(project.configurations.runtime)
-                        pom.scopeMappings.addMapping(MavenPlugin.RUNTIME_PRIORITY, project.configurations.shadow, Conf2ScopeMappingContainer.RUNTIME)
+                        pom.scopeMappings.addMapping(org.gradle.api.plugins.MavenPlugin.RUNTIME_PRIORITY,
+                                project.configurations.shadow,
+                                org.gradle.api.artifacts.maven.Conf2ScopeMappingContainer.RUNTIME)
                     }
                 }
             }


### PR DESCRIPTION
The 'maven' plugin which is deprecated for quite some time is finally [removed](https://github.com/gradle/gradle/commit/53d7c1bcf272ff9bf1fc8e2145b458cb9072d06b) in Gradle 7.0. This also [affects](https://github.com/gradle/gradle/commit/eafc8d71fc2cf1bcfe565432d686cc25c06aedb9) the related classes (their replacements already live under org.gradle.api.publish.maven).

The ShadowJavaPlugin class currently imports them which makes it incompatible with Gradle 7 at compile time. By removing the imports and using Groovy's def variable declaration, the search for those old classes is deferred to runtime, only being called when the 'maven' plugin is applied and the classes are there as expected. So this change is compatible with use of the plugin in older Gradle versions.

As Gradle emits warnings for the jcenter repository, claiming it to be removed in Gradle 8, I followed their suggestion to change it to mavenCentral.

With this change, I am able to build and use this plugin with Gradle 7.
Fixes #658