### PR TITLE
Moved graldeApi() exclusion to the task configuration.

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.groovy
@@ -87,6 +87,9 @@ class ShadowJavaPlugin implements Plugin<Project> {
             shadow.configurations = [project.configurations.findByName('runtimeClasspath') ?
                                              project.configurations.runtimeClasspath : project.configurations.runtime]
             shadow.exclude('META-INF/INDEX.LIST', 'META-INF/*.SF', 'META-INF/*.DSA', 'META-INF/*.RSA', 'module-info.class')
+            shadow.dependencies {
+                exclude(dependency(project.dependencies.gradleApi()))
+            }
         }
         project.artifacts.add(ShadowBasePlugin.CONFIGURATION_NAME, project.tasks.named(SHADOW_JAR_TASK_NAME))
         configureShadowUpload()

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowPlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowPlugin.groovy
@@ -34,15 +34,6 @@ class ShadowPlugin implements Plugin<Project> {
                     }
                 }
             }
-
-            afterEvaluate {
-                plugins.withId('java-gradle-plugin') {
-                    // needed to prevent inclusion of gradle-api into shadow JAR
-                    configurations.named(JavaPlugin.API_CONFIGURATION_NAME) {
-                        dependencies.remove(project.dependencies.gradleApi())
-                    }
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
Solves #674 

I've eliminated the `Project#afterEvaluate` call and added a bit to filter out the `gradleApi()` dependency to the dependency filter for the default task. The call to `Project#afterEvaluate` was conflicting with another plugin making a similar call, so removal is the recommended strategy. [See also](https://discuss.gradle.org/t/is-project-afterevaluate-the-proper-way-for-gradle-plugin-to-dynamically-create-default-tasks/31349).