### PR TITLE
Fix Gradle 7.1 JavaExec.main property deprecation

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.groovy
@@ -80,7 +80,7 @@ class ShadowApplicationPlugin implements Plugin<Project> {
         project.tasks.register(SHADOW_RUN_TASK_NAME, JavaJarExec) { run ->
             def install = project.tasks.named(SHADOW_INSTALL_TASK_NAME, Sync)
             run.dependsOn SHADOW_INSTALL_TASK_NAME
-            run.setMain('-jar')
+            run.mainClass.set('-jar')
             run.description = 'Runs this project as a JVM application using the shadow jar'
             run.group = ApplicationPlugin.APPLICATION_GROUP
             run.conventionMapping.jvmArgs = { pluginConvention.applicationDefaultJvmArgs }


### PR DESCRIPTION
JavaExec.main has been deprecated in Gradle 7.1 and will be removed in
Gradle 8.0. Instead, JavaExec.mainClass property should be used.