### PR TITLE
Support for Toolchains for JVM Projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,12 +62,14 @@ repositories {
 }
 
 test {
+    useJUnitPlatform()
+
     if (System.env.CI == 'true') {
         testLogging.showStandardStreams = true
         minHeapSize "1g"
         maxHeapSize "1g"
     }
-    
+
     systemProperty 'java.io.tmpdir', buildDir.absolutePath
 }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -16,10 +16,10 @@ dependencies {
         exclude group: 'org.ow2.asm'
     }
 
-    testImplementation("org.spockframework:spock-core:2.0-M4-groovy-3.0") {
+    testImplementation('org.spockframework:spock-core:2.0-groovy-3.0') {
         exclude group: 'org.codehaus.groovy'
     }
-    testImplementation "org.spockframework:spock-junit4:2.0-M4-groovy-3.0"
+    testImplementation 'org.spockframework:spock-junit4:2.0-groovy-3.0'
     testImplementation 'xmlunit:xmlunit:1.6'
     testImplementation 'org.apache.commons:commons-lang3:3.12.0'
     testImplementation 'com.google.guava:guava:30.1.1-jre'

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.groovy
@@ -11,9 +11,13 @@ import org.gradle.api.file.CopySpec
 import org.gradle.api.plugins.ApplicationPlugin
 import org.gradle.api.plugins.ApplicationPluginConvention
 import org.gradle.api.plugins.JavaApplication
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Sync
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.application.CreateStartScripts
+import org.gradle.jvm.toolchain.JavaLauncher
+import org.gradle.jvm.toolchain.JavaToolchainService
 
 class ShadowApplicationPlugin implements Plugin<Project> {
 
@@ -87,7 +91,15 @@ class ShadowApplicationPlugin implements Plugin<Project> {
             run.conventionMapping.jarFile = {
                 project.file("${install.get().destinationDir.path}/lib/${jar.get().archivePath.name}")
             }
+            configureJavaLauncher(run)
         }
+    }
+
+    private void configureJavaLauncher(JavaJarExec run) {
+        def toolchain = project.getExtensions().getByType(JavaPluginExtension.class).toolchain
+        JavaToolchainService service = project.getExtensions().getByType(JavaToolchainService.class)
+        Provider<JavaLauncher> defaultLauncher = service.launcherFor(toolchain)
+        run.getJavaLauncher().set(defaultLauncher)
     }
 
     protected void addCreateScriptsTask(Project project) {

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ApplicationSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ApplicationSpec.groovy
@@ -1,6 +1,5 @@
 package com.github.jengelman.gradle.plugins.shadow
 
-import com.github.jengelman.gradle.plugins.shadow.util.AppendableMavenFileRepository
 import com.github.jengelman.gradle.plugins.shadow.util.PluginSpecification
 import org.apache.tools.zip.ZipFile
 import org.gradle.testkit.runner.BuildResult
@@ -10,14 +9,6 @@ import java.util.jar.Attributes
 import java.util.jar.JarFile
 
 class ApplicationSpec extends PluginSpecification {
-
-    AppendableMavenFileRepository repo
-    AppendableMavenFileRepository publishingRepo
-
-    def setup() {
-        repo = repo()
-        publishingRepo = repo('remote_repo')
-    }
 
     def 'integration with application plugin'() {
         given:
@@ -124,7 +115,7 @@ class ApplicationSpec extends PluginSpecification {
         ZipFile zipFile = new ZipFile(zip)
         println zipFile.entries.collect { it.name }
         assert zipFile.entries.find { it.name == 'myapp-shadow-1.0/lib/myapp-1.0-all.jar' }
-        assert zipFile.entries.find { it.name == 'myapp-shadow-1.0/lib/a-1.0.jar'}
+        assert zipFile.entries.find { it.name == 'myapp-shadow-1.0/lib/a-1.0.jar' }
 
         cleanup:
         zipFile?.close()

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/PublishingSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/PublishingSpec.groovy
@@ -3,155 +3,16 @@ package com.github.jengelman.gradle.plugins.shadow
 import com.github.jengelman.gradle.plugins.shadow.util.AppendableMavenFileRepository
 import com.github.jengelman.gradle.plugins.shadow.util.PluginSpecification
 import groovy.json.JsonSlurper
+import groovy.xml.XmlSlurper
 import org.gradle.api.attributes.Bundling
 import org.gradle.api.attributes.Usage
-import spock.lang.Issue
 
 class PublishingSpec extends PluginSpecification {
 
-    AppendableMavenFileRepository repo
     AppendableMavenFileRepository publishingRepo
 
     def setup() {
-        repo = repo()
         publishingRepo = repo('remote_repo')
-    }
-
-    def "publish shadow jar with maven plugin"() {
-        given:
-        repo.module('shadow', 'a', '1.0')
-                .insertFile('a.properties', 'a')
-                .insertFile('a2.properties', 'a2')
-                .publish()
-        repo.module('shadow', 'b', '1.0')
-                .insertFile('b.properties', 'b')
-                .publish()
-
-        settingsFile << "rootProject.name = 'maven'"
-        buildFile << """
-            apply plugin: 'maven'
-
-            dependencies {
-               implementation 'shadow:a:1.0'
-               shadow 'shadow:b:1.0'
-            }
-            
-            shadowJar {
-               archiveBaseName = 'maven-all'
-               archiveClassifier = null
-               archiveClassifier.convention(null)
-            }
-            
-            uploadShadow {
-               repositories {
-                   mavenDeployer {
-                       repository(url: "${publishingRepo.uri}")
-                   }
-               }
-            }
-        """.stripIndent()
-
-        when:
-        runWithDeprecationWarnings('uploadShadow')
-
-        then: 'Check that shadow artifact exists'
-        File publishedFile = publishingRepo.rootDir.file('shadow/maven-all/1.0/maven-all-1.0.jar').canonicalFile
-        assert publishedFile.exists()
-
-        and: 'Check contents of shadow artifact'
-        contains(publishedFile, ['a.properties', 'a2.properties'])
-
-        and: 'Check that shadow artifact pom exists and contents'
-        File pom = publishingRepo.rootDir.file('shadow/maven-all/1.0/maven-all-1.0.pom').canonicalFile
-        assert pom.exists()
-
-        def contents = new XmlSlurper().parse(pom)
-        assert contents.dependencies.size() == 1
-        assert contents.dependencies[0].dependency.size() == 1
-
-        def dependency = contents.dependencies[0].dependency[0]
-        assert dependency.groupId.text() == 'shadow'
-        assert dependency.artifactId.text() == 'b'
-        assert dependency.version.text() == '1.0'
-    }
-
-    def "exclude api and implementation dependencies when publishing shadow jar with maven plugin"() {
-        given:
-        repo.module('shadow', 'a', '1.0')
-                .insertFile('a.properties', 'a')
-                .insertFile('a2.properties', 'a2')
-                .publish()
-        repo.module('shadow', 'b', '1.0')
-                .insertFile('b.properties', 'b')
-                .publish()
-
-        settingsFile << "rootProject.name = 'maven'"
-        buildFile << """
-            apply plugin: 'java-library'
-            apply plugin: 'maven'
-
-            dependencies {
-               api 'shadow:a:1.0'
-               implementation 'shadow:b:1.0'
-            }
-            
-            uploadShadow {
-               repositories {
-                   mavenDeployer {
-                       repository(url: "${publishingRepo.uri}")
-                   }
-               }
-            }
-        """.stripIndent()
-
-        when:
-        runWithDeprecationWarnings('uploadShadow')
-
-        then: 'Check that shadow artifact exists'
-        File publishedFile = publishingRepo.rootDir.file('shadow/maven/1.0/maven-1.0-all.jar').canonicalFile
-        assert publishedFile.exists()
-
-        and: 'Check contents of shadow artifact'
-        contains(publishedFile, ['a.properties', 'a2.properties'])
-
-        and: 'Check that shadow artifact pom exists and contents'
-        File pom = publishingRepo.rootDir.file('shadow/maven/1.0/maven-1.0.pom').canonicalFile
-        assert pom.exists()
-
-        def contents = new XmlSlurper().parse(pom)
-        assert contents.dependencies.size() == 0
-    }
-
-    @Issue('SHADOW-347')
-    def "maven install with application plugin"() {
-        given:
-        repo.module('shadow', 'a', '1.0')
-                .insertFile('a.properties', 'a')
-                .insertFile('a2.properties', 'a2')
-                .publish()
-        repo.module('shadow', 'b', '1.0')
-                .insertFile('b.properties', 'b')
-                .publish()
-
-        settingsFile << "rootProject.name = 'maven'"
-        buildFile << """
-            apply plugin: 'maven'
-            apply plugin: 'application'
-
-            mainClassName = 'my.App'
-
-            dependencies {
-               implementation 'shadow:a:1.0'
-               shadow 'shadow:b:1.0'
-            }
-        """.stripIndent()
-
-        when:
-        // The Maven plugin is deprecated
-        runWithDeprecationWarnings('install')
-
-        then:
-        noExceptionThrown()
     }
 
     def "publish shadow jar with maven-publish plugin"() {

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/RelocationSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/RelocationSpec.groovy
@@ -184,10 +184,10 @@ class RelocationSpec extends PluginSpecification {
     def "relocate does not drop dependency resources"() {
         given: 'Core project with dependency and resource'
         file('core/build.gradle') << """
-        apply plugin: 'java'
+        apply plugin: 'java-library'
         
         repositories { maven { url "${repo.uri}" } }
-        dependencies { implementation 'junit:junit:3.8.2' }
+        dependencies { api 'junit:junit:3.8.2' }
         """.stripIndent()
 
         file('core/src/main/resources/TEST') << 'TEST RESOURCE'

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/RelocationCachingSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/RelocationCachingSpec.groovy
@@ -7,7 +7,7 @@ class RelocationCachingSpec extends AbstractCachingSpec {
     def 'shadowJar is cached correctly when relocation is added'() {
         given:
         buildFile << """
-            dependencies { compile 'junit:junit:3.8.2' }
+            dependencies { implementation 'junit:junit:3.8.2' }
         """.stripIndent()
 
         file('src/main/java/server/Server.java') << """
@@ -30,7 +30,7 @@ class RelocationCachingSpec extends AbstractCachingSpec {
 
         when:
         changeConfigurationTo """
-            dependencies { compile 'junit:junit:3.8.2' }
+            dependencies { implementation 'junit:junit:3.8.2' }
 
             shadowJar {
                relocate 'junit.framework', 'foo.junit.framework'

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/ShadowJarCachingSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/caching/ShadowJarCachingSpec.groovy
@@ -184,7 +184,7 @@ class ShadowJarCachingSpec extends AbstractCachingSpec {
 
         when:
         changeConfigurationTo """
-            dependencies { compile 'junit:junit:3.8.2' }
+            dependencies { implementation 'junit:junit:3.8.2' }
 
             shadowJar {
                dependencies {

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/PluginSpecification.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/PluginSpecification.groovy
@@ -35,11 +35,11 @@ class PluginSpecification extends Specification {
         println buildFile.text
     }
 
-    String getDefaultBuildScript() {
+    String getDefaultBuildScript(String javaPlugin = 'java') {
         return """
         plugins {
-            id 'java'
-            id 'com.github.johnrengelman.shadow'
+            id '${javaPlugin}'
+            id 'com.github.johnrengelman.shadow' version '${SHADOW_VERSION}'
         }
 
         version = "1.0"
@@ -91,7 +91,7 @@ class PluginSpecification extends Specification {
         }
     }
 
-    private static boolean containsDeprecationWarning(String output) {
+    static boolean containsDeprecationWarning(String output) {
         output.contains("has been deprecated and is scheduled to be removed in Gradle") ||
                 output.contains("has been deprecated. This is scheduled to be removed in Gradle")
     }

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/file/TestFile.java
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/file/TestFile.java
@@ -36,6 +36,7 @@ import java.util.*;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 
 public class TestFile extends File {


### PR DESCRIPTION
Addresses https://github.com/johnrengelman/shadow/issues/690

Similarly to [Application Plugin](https://github.com/gradle/gradle/blob/master/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPlugin.java#L169), the `ShadowApplicationPlugin` should configure the `javaLauncher` in order to leverage [Toolchains](https://docs.gradle.org/current/userguide/toolchains.html)

I created this change on top of https://github.com/johnrengelman/shadow/pull/672 to avoid duplicated efforts to fix the tests suite