### PR TITLE
Upgrade to ASM 9.2 for JDK 18 support.

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -6,8 +6,8 @@ dependencies {
 
     implementation "com.gradle.publish:plugin-publish-plugin:0.14.0"
     implementation 'org.jdom:jdom2:2.0.6'
-    implementation 'org.ow2.asm:asm:9.1'
-    implementation 'org.ow2.asm:asm-commons:9.1'
+    implementation 'org.ow2.asm:asm:9.2'
+    implementation 'org.ow2.asm:asm-commons:9.2'
     implementation 'commons-io:commons-io:2.8.0'
     implementation 'org.apache.ant:ant:1.10.9'
     implementation 'org.codehaus.plexus:plexus-utils:3.3.0'


### PR DESCRIPTION
Currently running Gradle build which uses JavaToolchanin configured with JDK 18 results in this exception from the Shadow plugin:
```
Caused by: java.lang.IllegalArgumentException: Unsupported class file major version 62
        at shadow.org.objectweb.asm.ClassReader.<init>(ClassReader.java:196)
        at shadow.org.objectweb.asm.ClassReader.<init>(ClassReader.java:177)
        at shadow.org.objectweb.asm.ClassReader.<init>(ClassReader.java:163)
        at shadow.org.objectweb.asm.ClassReader.<init>(ClassReader.java:284)
        at com.github.jengelman.gradle.plugins.shadow.tasks.ShadowCopyAction$StreamAction.remapClass(ShadowCopyAction.groovy:342)
        at com.github.jengelman.gradle.plugins.shadow.tasks.ShadowCopyAction$StreamAction.remapClass(ShadowCopyAction.groovy:328)
        at com.github.jengelman.gradle.plugins.shadow.tasks.ShadowCopyAction$StreamAction.visitFile(ShadowCopyAction.groovy:242)
        ... 150 more
```