### PR TITLE
Make JUnit tests run again

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,4 +23,6 @@ dependencies {
     testImplementation 'xmlunit:xmlunit:1.6'
     testImplementation 'org.apache.commons:commons-lang3:3.12.0'
     testImplementation 'com.google.guava:guava:30.1.1-jre'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
 }


### PR DESCRIPTION
Oops, it seems my PR (#672) to fix the Spock tests ended up breaking the JUnit tests. These two dependencies are needed when using `useJUnitPlatform()`.