### PR TITLE
Fix ManifestResourceTransformer

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation 'org.ow2.asm:asm:9.2'
     implementation 'org.ow2.asm:asm-commons:9.2'
     implementation 'commons-io:commons-io:2.8.0'
-    implementation 'org.apache.ant:ant:1.10.9'
+    implementation 'org.apache.ant:ant:1.10.11'
     implementation 'org.codehaus.plexus:plexus-utils:3.3.0'
     implementation "org.apache.logging.log4j:log4j-core:2.14.1"
     implementation('org.vafer:jdependency:2.7.0') {

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/TransformerSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/TransformerSpec.groovy
@@ -716,7 +716,7 @@ staticExtensionClasses=com.acme.bar.SomeStaticExtension'''.stripIndent()).write(
         'IncludeResourceTransformer'        | '{ resource = "test.file"; file = file("test/some.file") }'
         'Log4j2PluginsCacheFileTransformer' | ''
         'ManifestAppenderTransformer'       | ''
-        // 'ManifestResourceTransformer'       | ''
+        'ManifestResourceTransformer'       | ''
         'PropertiesFileTransformer'         | '{ keyTransformer = { it.toLowerCase() } }'
         'ServiceFileTransformer'            | ''
         'XmlAppendingTransformer'           | ''


### PR DESCRIPTION
In #647, I had to leave the test for `ManifestResourceTransformer` commented out, because that transformer has been broken since `JarOutputStream` was replaced by `ZipOutputStream` in Shadow 0.9.0/1.0.0. That was due to an issue upstream in Ant (https://github.com/apache/ant/pull/145) which has been fixed since version 1.10.10.