### PR TITLE
Remove maven plugin

### DIFF
--- a/src/docs/configuration/README.md
+++ b/src/docs/configuration/README.md
@@ -42,7 +42,7 @@ they are still required for runtime execution.
 In these scenarios, Shadow creates a `shadow` configuration to declare these dependencies.
 Dependencies added to the `shadow` configuration are **not** bundled into the output JAR.
 Think of `configurations.shadow` as unmerged, runtime dependencies.
-The integration with the `maven` and `maven-publish` plugins will automatically configure dependencies added
+The integration with the `maven-publish` plugin will automatically configure dependencies added
 to `configurations.shadow` as `RUNTIME` scope dependencies in the resulting POM file.
 
 Additionally, Shadow automatically configures the manifest of the `shadowJar` task to contain a `Class-Path` entry

--- a/src/docs/getting-started/README.md
+++ b/src/docs/getting-started/README.md
@@ -48,9 +48,6 @@ following behavior:
   * `META-INF/*.DSA`
   * `META-INF/*.RSA`
 * Creates and registers the `shadow` component in the project (used for integrating with `maven-publish`).
-* Configures the `uploadShadow` task (as part of the `maven` plugin) with the following behavior:
-  * Removes the `compile` and `runtime` configurations from the `pom.xml` file mapping.
-  * Adds the `shadow` configuration to the `pom.xml` file as `RUNTIME` scope.
 
 ## Shadowing Gradle Plugins
 

--- a/src/docs/publishing/README.md
+++ b/src/docs/publishing/README.md
@@ -27,30 +27,6 @@ publishing {
 }
 ```
 
-## Publishing with Maven Plugin
-
-> The `maven` plugin has been deprecated in recent versions of Gradle.
-The documentation is kept here for reference, but is not longer tested as part of the CI process.
-
-The Shadow plugin will automatically configure the necessary tasks in the presence of Gradle's
-`maven` plugin.
-To publish the JAR, simply configure the publish location for the `uploadShadow` task and execute it.
-
-```
-// Publishing a Shadow JAR with the Maven Plugin
-apply plugin: 'java'
-apply plugin: 'maven'
-apply plugin: 'com.github.johnrengelman.shadow'
-
-uploadShadow {
-  repositories {
-    mavenDeployer {
-      repository(url: "http://repo.myorg.com")
-    }
-  }
-}
-```
-
 ## Shadow Configuration and Publishing
 
 The Shadow plugin provides a custom configuration (`configurations.shadow`) to specify

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.groovy
@@ -43,19 +43,6 @@ class ShadowApplicationPlugin implements Plugin<Project> {
 
         configureJarMainClass(project)
         configureInstallTask(project)
-
-        project.pluginManager.withPlugin('maven') {
-            project.configurations.archives.with {
-                artifacts.findAll {
-                    if (it.hasProperty("provider")) {
-                        it.provider.get().is(project.tasks.shadowDistZip) ||
-                                it.provider.get().is(project.tasks.shadowDistTar)
-                    }
-                }.each {
-                    artifacts.remove it
-                }
-            }
-        }
     }
 
     protected void configureJarMainClass(Project project) {

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.groovy
@@ -1,7 +1,6 @@
 package com.github.jengelman.gradle.plugins.shadow
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.attributes.Bundling
@@ -9,7 +8,6 @@ import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.attributes.Usage
 import org.gradle.api.plugins.JavaPluginConvention
-import org.gradle.api.tasks.Upload
 import org.gradle.configuration.project.ProjectConfigurationActionContainer
 import org.gradle.util.GradleVersion
 
@@ -18,7 +16,6 @@ import javax.inject.Inject
 class ShadowJavaPlugin implements Plugin<Project> {
 
     static final String SHADOW_JAR_TASK_NAME = 'shadowJar'
-    static final String SHADOW_UPLOAD_TASK = 'uploadShadow'
     static final String SHADOW_GROUP = 'Shadow'
 
     private final ProjectConfigurationActionContainer configurationActionContainer;
@@ -92,31 +89,5 @@ class ShadowJavaPlugin implements Plugin<Project> {
             }
         }
         project.artifacts.add(ShadowBasePlugin.CONFIGURATION_NAME, project.tasks.named(SHADOW_JAR_TASK_NAME))
-        configureShadowUpload()
-    }
-
-    private void configureShadowUpload() {
-        configurationActionContainer.add(new Action<Project>() {
-            void execute(Project project) {
-                project.pluginManager.withPlugin('maven') {
-                    project.tasks.withType(Upload).configureEach { upload ->
-                        if (upload.name != SHADOW_UPLOAD_TASK) {
-                            return
-                        }
-                        upload.configuration = project.configurations.shadow
-                        def pom = upload.repositories.mavenDeployer.pom
-                        if (project.configurations.findByName("api")) {
-                            pom.scopeMappings.mappings.remove(project.configurations.api)
-                        }
-                        pom.scopeMappings.mappings.remove(project.configurations.compile)
-                        pom.scopeMappings.mappings.remove(project.configurations.implementation)
-                        pom.scopeMappings.mappings.remove(project.configurations.runtime)
-                        pom.scopeMappings.addMapping(org.gradle.api.plugins.MavenPlugin.RUNTIME_PRIORITY,
-                                project.configurations.shadow,
-                                org.gradle.api.artifacts.maven.Conf2ScopeMappingContainer.RUNTIME)
-                    }
-                }
-            }
-        })
     }
 }


### PR DESCRIPTION
Maven plugin (and upload task) has been completely removed from Gradle 7, which is now the minimum required version by Shadow. This PR removes the remnants of it.