### PR TITLE
refactor: directly expose `static final String` fields / remove getters

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.groovy
@@ -21,9 +21,9 @@ import org.gradle.jvm.toolchain.JavaToolchainService
 
 class ShadowApplicationPlugin implements Plugin<Project> {
 
-    static final String SHADOW_RUN_TASK_NAME = 'runShadow'
-    static final String SHADOW_SCRIPTS_TASK_NAME = 'startShadowScripts'
-    static final String SHADOW_INSTALL_TASK_NAME = 'installShadowDist'
+    public static final String SHADOW_RUN_TASK_NAME = 'runShadow'
+    public static final String SHADOW_SCRIPTS_TASK_NAME = 'startShadowScripts'
+    public static final String SHADOW_INSTALL_TASK_NAME = 'installShadowDist'
 
     private Project project
     private ApplicationPluginConvention pluginConvention

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowBasePlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowBasePlugin.groovy
@@ -8,8 +8,8 @@ import org.gradle.util.GradleVersion
 
 class ShadowBasePlugin implements Plugin<Project> {
 
-    static final String EXTENSION_NAME = 'shadow'
-    static final String CONFIGURATION_NAME = 'shadow'
+    public static final String EXTENSION_NAME = 'shadow'
+    public static final String CONFIGURATION_NAME = 'shadow'
 
     @Override
     void apply(Project project) {

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.groovy
@@ -15,8 +15,8 @@ import javax.inject.Inject
 
 class ShadowJavaPlugin implements Plugin<Project> {
 
-    static final String SHADOW_JAR_TASK_NAME = 'shadowJar'
-    static final String SHADOW_GROUP = 'Shadow'
+    public static final String SHADOW_JAR_TASK_NAME = 'shadowJar'
+    public static final String SHADOW_GROUP = 'Shadow'
 
     private final ProjectConfigurationActionContainer configurationActionContainer;
 

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/KnowsTask.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/KnowsTask.groovy
@@ -6,8 +6,8 @@ import org.gradle.api.tasks.TaskAction
 
 class KnowsTask extends DefaultTask {
 
-    static final String NAME = "knows"
-    static final String DESC = "Do you know who knows?"
+    public static final String NAME = "knows"
+    public static final String DESC = "Do you know who knows?"
 
     @TaskAction
     def knows() {

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformer.groovy
@@ -42,7 +42,7 @@ import org.gradle.api.file.FileTreeElement
 class ComponentsXmlResourceTransformer implements Transformer {
     private Map<String, Xpp3Dom> components = new LinkedHashMap<String, Xpp3Dom>()
 
-    static final String COMPONENTS_XML_PATH = "META-INF/plexus/components.xml"
+    public static final String COMPONENTS_XML_PATH = "META-INF/plexus/components.xml"
 
     boolean canTransformResource(FileTreeElement element) {
         def path = element.relativePath.pathString

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/XmlAppendingTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/XmlAppendingTransformer.groovy
@@ -45,7 +45,7 @@ import org.xml.sax.SAXException
  */
 @CacheableTransformer
 class XmlAppendingTransformer implements Transformer {
-    static final String XSI_NS = "http://www.w3.org/2001/XMLSchema-instance"
+    public static final String XSI_NS = "http://www.w3.org/2001/XMLSchema-instance"
 
     @Input
     boolean ignoreDtd = true

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformerTest.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformerTest.groovy
@@ -34,7 +34,7 @@ import static org.junit.Assert.*
  * Test for {@link ManifestAppenderTransformer}.
  */
 class ManifestAppenderTransformerTest extends TransformerTestSupport {
-    static final String MANIFEST_NAME = "META-INF/MANIFEST.MF"
+    public static final String MANIFEST_NAME = "META-INF/MANIFEST.MF"
 
     private ManifestAppenderTransformer transformer
 

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/PluginSpecification.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/PluginSpecification.groovy
@@ -16,7 +16,7 @@ class PluginSpecification extends Specification {
 
     @Rule TemporaryFolder dir
 
-    static final String SHADOW_VERSION = PluginSpecification.classLoader.getResource("shadow-version.txt").text.trim()
+    public static final String SHADOW_VERSION = PluginSpecification.classLoader.getResource("shadow-version.txt").text.trim()
 
     AppendableMavenFileRepository repo
 


### PR DESCRIPTION
Omitting the visibility modifier creates a Groovy _property_ [1], which
is composed by:
* a _private_ backing field
* a public getter
* (+ setter if the property is not `final`)

It is unlikely to be an intended design as it makes access to those
fields awkward from statically typed languages
`ShadowBasePlugin.getCONFIGURATION_NAME()`.

This commit replaces such _properties_ with _public fields_ only.

This is a backward incompatible change as this removes public getters.

Here is what the generated class looked liked before this
commit (7.0.0):

```
$ javap -p -c -constants ShadowBasePlugin.class
Compiled from "ShadowBasePlugin.groovy"
public class com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin implements org.gradle.api.Plugin<org.gradle.api.Project>, groovy.lang.GroovyObject {
  private static final java.lang.String EXTENSION_NAME = "shadow";

  private static final java.lang.String CONFIGURATION_NAME = "shadow";
[...]
  public static java.lang.String getEXTENSION_NAME();
    Code:
       0: getstatic     #86                 // Field EXTENSION_NAME:Ljava/lang/String;
       3: areturn

  public static java.lang.String getCONFIGURATION_NAME();
    Code:
       0: getstatic     #111                // Field CONFIGURATION_NAME:Ljava/lang/String;
       3: areturn
```

[1] https://groovy-lang.org/objectorientation.html#properties