### PR TITLE
Mark the Log4j2PluginsCacheFileTransformer as cacheable.

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2PluginsCacheFileTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2PluginsCacheFileTransformer.groovy
@@ -41,6 +41,7 @@ import static org.apache.logging.log4j.core.config.plugins.processor.PluginProce
  * @see <a href="https://github.com/edwgiz/maven-shaded-log4j-transformer">edwgiz/maven-shaded-log4j-transformer</a>
  * @see <a href="https://github.com/edwgiz/maven-shaded-log4j-transformer/blob/master/src/main/java/com/github/edwgiz/mavenShadePlugin/log4j2CacheTransformer/PluginsCacheFileTransformer.java">PluginsCacheFileTransformer.java</a>
  */
+@CacheableTransformer
 class Log4j2PluginsCacheFileTransformer implements Transformer {
 
     private final List<File> temporaryFiles


### PR DESCRIPTION
This transfomer doesn't take any custom inputs; it has
deterministic behaviour based on the files getting shaded.
This means it doesn't pose any additional requirements on the
cacheability of the overall ShadowJar task. Therefore we
should be able to mark it cacheable.