### PR TITLE
CVE-2021-44228: Update to non-vulnerable log4j version 2.15.0.

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'commons-io:commons-io:2.11.0'
     implementation 'org.apache.ant:ant:1.10.11'
     implementation 'org.codehaus.plexus:plexus-utils:3.4.1'
-    implementation "org.apache.logging.log4j:log4j-core:2.15.0-rc2"
+    implementation "org.apache.logging.log4j:log4j-core:2.15.0"
     implementation('org.vafer:jdependency:2.7.0') {
         exclude group: 'org.ow2.asm'
     }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'commons-io:commons-io:2.11.0'
     implementation 'org.apache.ant:ant:1.10.11'
     implementation 'org.codehaus.plexus:plexus-utils:3.4.1'
-    implementation "org.apache.logging.log4j:log4j-core:2.14.1"
+    implementation "org.apache.logging.log4j:log4j-core:2.15.0-rc2"
     implementation('org.vafer:jdependency:2.7.0') {
         exclude group: 'org.ow2.asm'
     }


### PR DESCRIPTION
log4j 2.0 up to 2.15.0-rc1 are vulnerable: CVE-2021-44228

Although this is probably not relevant for this plugin it's better to be safe than sorry.