### PR TITLE
Fix the plugin dependency identifier in the docs

### DIFF
--- a/src/docs/getting-started/README.md
+++ b/src/docs/getting-started/README.md
@@ -15,7 +15,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath 'gradle.plugin.com.github.jengelman.gradle.plugins:shadow:@version@'
+        classpath 'gradle.plugin.com.github.johnrengelman:shadow:@version@'
     }
 }
 


### PR DESCRIPTION
Fixes the instructions for adding the Gradle plugin to the buildscript classpath in the user guide.

Based on the instructions in the Gradle plugin portal:
https://plugins.gradle.org/plugin/com.github.johnrengelman.shadow

Fixes #750.