### PR TITLE
Do not add a dependencies block if it's already there

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowExtension.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowExtension.groovy
@@ -28,8 +28,8 @@ class ShadowExtension {
 
         publication.pom { MavenPom pom ->
             pom.withXml { xml ->
-                def dependenciesNode = xml.asNode().appendNode('dependencies')
-
+                def dependenciesNode = xml.asNode().get('dependencies')?.get(0) ?: xml.asNode().appendNode('dependencies')
+                dependenciesNode.value = ""
                 project.configurations.shadow.allDependencies.each {
                     if ((it instanceof ProjectDependency) || ! (it instanceof SelfResolvingDependency)) {
                         def dependencyNode = dependenciesNode.appendNode('dependency')


### PR DESCRIPTION
Sometimes the publication already has a pom, so adding a node will result in a duplicated dependencies block