### PR TITLE
Fix retrieval of dependencies node after #769

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,9 @@ apply from: file('gradle/dependencies.gradle')
 repositories {
     gradlePluginPortal()
     mavenCentral()
+
+    // for r8 dependency
+    google()
 }
 
 test {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -5,6 +5,9 @@ apply plugin: 'groovy'
 repositories {
     gradlePluginPortal()
     mavenCentral()
+
+    // for r8 dependency
+    google()
 }
 
 ScriptHolder holder = new ScriptHolder()

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -15,6 +15,8 @@ dependencies {
         exclude group: 'org.ow2.asm'
     }
 
+    implementation 'com.android.tools:r8:3.3.75'
+
     testImplementation('org.spockframework:spock-core:2.0-groovy-3.0') {
         exclude group: 'org.codehaus.groovy'
     }

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowExtension.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowExtension.groovy
@@ -28,8 +28,7 @@ class ShadowExtension {
 
         publication.pom { MavenPom pom ->
             pom.withXml { xml ->
-                def dependenciesNode = xml.asNode().get('dependencies')?.get(0) ?: xml.asNode().appendNode('dependencies')
-                dependenciesNode.value = ""
+                def dependenciesNode = xml.asNode().get('dependencies') ?: xml.asNode().appendNode('dependencies')
                 project.configurations.shadow.allDependencies.each {
                     if ((it instanceof ProjectDependency) || ! (it instanceof SelfResolvingDependency)) {
                         def dependencyNode = dependenciesNode.appendNode('dependency')

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/UnusedTracker.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/UnusedTracker.groovy
@@ -7,40 +7,24 @@ import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.SelfResolvingDependency
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.InputFiles
-import org.vafer.jdependency.Clazz
-import org.vafer.jdependency.Clazzpath
-import org.vafer.jdependency.ClazzpathUnit
+
+import java.nio.file.Path
 
 /** Tracks unused classes in the project classpath. */
-class UnusedTracker {
-    private final FileCollection toMinimize
-    private final List<ClazzpathUnit> projectUnits
-    private final Clazzpath cp = new Clazzpath()
+abstract class UnusedTracker {
+    protected final FileCollection toMinimize
 
-    private UnusedTracker(Iterable<File> classDirs, FileCollection classJars, FileCollection toMinimize) {
+    protected UnusedTracker(FileCollection toMinimize) {
         this.toMinimize = toMinimize
-        projectUnits = classDirs.collect { cp.addClazzpathUnit(it) }
-        projectUnits.addAll(classJars.collect { cp.addClazzpathUnit(it) })
     }
 
-    Set<String> findUnused() {
-        Set<Clazz> unused = cp.clazzes
-        for (cpu in projectUnits) {
-            unused.removeAll(cpu.clazzes)
-            unused.removeAll(cpu.transitiveDependencies)
-        }
-        return unused.collect { it.name }.toSet()
+    Path getPathToProcessedClass(String classname) {
+        return null
     }
 
-    void addDependency(File jarOrDir) {
-        if (toMinimize.contains(jarOrDir)) {
-            cp.addClazzpathUnit(jarOrDir)
-        }
-    }
+    abstract Set<String> findUnused()
 
-    static UnusedTracker forProject(FileCollection apiJars, Iterable<File> sourceSetsClassesDirs, FileCollection toMinimize) {
-        return new UnusedTracker(sourceSetsClassesDirs, apiJars, toMinimize)
-    }
+    abstract void addDependency(File jarOrDir)
 
     @InputFiles
     FileCollection getToMinimize() {

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/UnusedTrackerUsingJDependency.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/UnusedTrackerUsingJDependency.groovy
@@ -1,0 +1,37 @@
+package com.github.jengelman.gradle.plugins.shadow.internal
+
+import org.gradle.api.file.FileCollection
+import org.vafer.jdependency.Clazz
+import org.vafer.jdependency.Clazzpath
+import org.vafer.jdependency.ClazzpathUnit
+
+/** Tracks unused classes in the project classpath using jdependency. */
+class UnusedTrackerUsingJDependency extends UnusedTracker {
+    private final List<ClazzpathUnit> projectUnits
+    private final Clazzpath cp = new Clazzpath()
+
+    private UnusedTrackerUsingJDependency(Iterable<File> classDirs, FileCollection classJars, FileCollection toMinimize) {
+        super(toMinimize)
+        projectUnits = classDirs.collect { cp.addClazzpathUnit(it) }
+        projectUnits.addAll(classJars.collect { cp.addClazzpathUnit(it) })
+    }
+
+    Set<String> findUnused() {
+        Set<Clazz> unused = cp.clazzes
+        for (cpu in projectUnits) {
+            unused.removeAll(cpu.clazzes)
+            unused.removeAll(cpu.transitiveDependencies)
+        }
+        return unused.collect { it.name }.toSet()
+    }
+
+    void addDependency(File jarOrDir) {
+        if (toMinimize.contains(jarOrDir)) {
+            cp.addClazzpathUnit(jarOrDir)
+        }
+    }
+
+    static UnusedTrackerUsingJDependency forProject(FileCollection apiJars, Iterable<File> sourceSetsClassesDirs, FileCollection toMinimize) {
+        return new UnusedTrackerUsingJDependency(sourceSetsClassesDirs, apiJars, toMinimize)
+    }
+}

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/UnusedTrackerUsingR8.java
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/UnusedTrackerUsingR8.java
@@ -1,0 +1,304 @@
+package com.github.jengelman.gradle.plugins.shadow.internal;
+
+import com.android.tools.r8.*;
+import com.android.tools.r8.origin.Origin;
+import org.apache.commons.io.FilenameUtils;
+import org.gradle.api.Project;
+import org.gradle.api.file.FileCollection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+
+/**
+ * An implementation of an UnusedTracker using R8.
+ * <p>
+ * This class is written in Java to avoid groovy madness especially in combination with R8.
+ */
+public class UnusedTrackerUsingR8 extends UnusedTracker {
+    private static final String TMP_DIR = "tmp/shadowJar/minimize";
+
+    private final Path tmpDir;
+    private final Collection<File> projectFiles;
+    private final Collection<File> dependencies;
+
+    private UnusedTrackerUsingR8(Path tmpDir, Iterable<File> classDirs, FileCollection classJars, FileCollection toMinimize) {
+        super(toMinimize);
+
+        this.tmpDir = tmpDir;
+
+        this.projectFiles = new ArrayList<>();
+        this.dependencies = new ArrayList<>();
+
+        for (File dir : classDirs) {
+            Path path = Paths.get(dir.getAbsolutePath());
+            collectClassFiles(path, projectFiles);
+        }
+
+        projectFiles.addAll(classJars.getFiles());
+    }
+
+    @Override
+    public Path getPathToProcessedClass(String classname) {
+        final String className = FilenameUtils.removeExtension(classname).replace('/', '.');
+        return Paths.get(tmpDir.toString(), className.replaceAll("\\.", "/") + ".class");
+    }
+
+    @Override
+    public Set<String> findUnused() {
+        // We effectively run R8 twice:
+        //  * first time disabling any processing, to retrieve all project classes
+        //  * second time with a full shrink run to get all unused classes
+        R8Command.Builder builder = R8Command.builder(new GradleDiagnosticHandler(true));
+
+        try {
+            populateBuilderWithProjectFiles(builder);
+        } catch (IOException ioe) {
+            throw new RuntimeException(ioe);
+        }
+
+        // add all dependency jars
+        for (File dep : dependencies) {
+            Path path = Paths.get(dep.getAbsolutePath());
+            builder.addProgramFiles(path);
+        }
+
+        final Set<String> removedClasses = new HashSet<>();
+
+        // Add any class from the usage list to the list of removed classes.
+        // This is a bit of a hack but the best things I could think of so far.
+        builder.setProguardUsageConsumer(new StringConsumer() {
+            private final String LINE_SEPARATOR = System.getProperty("line.separator");
+            private String  lastString = LINE_SEPARATOR;
+            private String  classString;
+            private boolean expectingSeparator;
+
+            @Override
+            public void accept(String s, DiagnosticsHandler handler) {
+                if (classString == null && Objects.equals(lastString, LINE_SEPARATOR)) {
+                    classString        = s;
+                    expectingSeparator = true;
+                } else if (expectingSeparator && Objects.equals(s, LINE_SEPARATOR)) {
+                    removedClasses.add(classString);
+                    classString        = null;
+                    expectingSeparator = false;
+                } else {
+                    classString        = null;
+                    expectingSeparator = false;
+                }
+
+                lastString = s;
+            }
+        });
+
+        List<String> proguardConfig;
+
+        try {
+            proguardConfig = getKeepRules();
+            proguardConfig.add("-dontoptimize");
+            proguardConfig.add("-dontobfuscate");
+            proguardConfig.add("-ignorewarnings");
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+
+        builder.addProguardConfiguration(proguardConfig, Origin.unknown());
+
+        // Set compilation mode to debug to disable any code of instruction
+        // level optimizations.
+        builder.setMode(CompilationMode.DEBUG);
+
+        builder.setProgramConsumer(new ClassFileConsumer() {
+            @Override
+            public void accept(ByteDataView byteDataView, String s, DiagnosticsHandler diagnosticsHandler) {
+                String name = typeNameToExternalClassName(s);
+
+                // any class that is actually going to be written to the output
+                // must not be present in the set of removed classes.
+                // Should not really be needed, but we prefer to be paranoid.
+                removedClasses.remove(name);
+
+                Path classFile = Paths.get(tmpDir.toString(), externalClassNameToInternal(name) + ".class");
+                try {
+                    Files.createDirectories(classFile.getParent());
+                    Files.write(classFile, byteDataView.getBuffer());
+                } catch (IOException ioe) {
+                    throw new RuntimeException(ioe);
+                }
+            }
+
+            @Override
+            public void finished(DiagnosticsHandler diagnosticsHandler) {}
+        });
+
+        try {
+            R8.run(builder.build());
+        } catch (CompilationFailedException cfe) {
+            throw new RuntimeException(cfe);
+        }
+
+        return removedClasses;
+    }
+
+    private static String typeNameToExternalClassName(String typeName) {
+        String className = typeName.startsWith("L") && typeName.endsWith(";") ?
+                typeName.substring(1, typeName.length() - 1) :
+                typeName;
+
+        return className.replaceAll("/", ".");
+    }
+
+    private static String externalClassNameToInternal(String className) {
+        return className.replaceAll("\\.", "/");
+    }
+
+    private static boolean isClassFile(Path path) {
+        String name = path.getFileName().toString().toLowerCase();
+        return !name.equals("module-info.class") && name.endsWith(".class");
+    }
+
+    private List<String> getKeepRules() throws IOException, CompilationFailedException {
+        R8Command.Builder builder = R8Command.builder(new GradleDiagnosticHandler(false));
+
+        populateBuilderWithProjectFiles(builder);
+
+        // add all dependencies as library jars to avoid warnings
+        for (File dep : dependencies) {
+            Path path = Paths.get(dep.getAbsolutePath());
+            builder.addLibraryFiles(path);
+        }
+
+        // disable everything, we just want to get a list of
+        // all project classes.
+        List<String> configs = new ArrayList<>();
+        configs.add("-dontshrink");
+        configs.add("-dontoptimize");
+        configs.add("-dontobfuscate");
+        configs.add("-ignorewarnings");
+        configs.add("-dontwarn");
+
+        builder.addProguardConfiguration(configs, Origin.unknown());
+
+        // Set compilation mode to debug to disable any code of instruction
+        // level optimizations.
+        builder.setMode(CompilationMode.DEBUG);
+
+        final List<String> keepRules = new ArrayList<>();
+
+        builder.setProgramConsumer(new ClassFileConsumer() {
+            @Override
+            public void accept(ByteDataView byteDataView, String s, DiagnosticsHandler diagnosticsHandler) {
+                String name = typeNameToExternalClassName(s);
+                keepRules.add("-keep,includedescriptorclasses class " + name + " { *; }");
+            }
+
+            @Override
+            public void finished(DiagnosticsHandler diagnosticsHandler) {}
+        });
+
+        R8.run(builder.build());
+        return keepRules;
+    }
+
+    private void populateBuilderWithProjectFiles(R8Command.Builder builder) throws IOException {
+        addJDKLibrary(builder);
+
+        for (File f : projectFiles) {
+            Path path = Paths.get(f.getAbsolutePath());
+
+            if (f.getAbsolutePath().endsWith(".class")) {
+                byte[] bytes = Files.readAllBytes(Paths.get(f.getAbsolutePath()));
+                builder.addClassProgramData(bytes, Origin.unknown());
+            } else {
+                builder.addProgramFiles(path);
+            }
+        }
+    }
+
+    private void collectClassFiles(Path dir, Collection<File> result) {
+        File file = dir.toFile();
+        if (file.exists()) {
+            File[] files = file.listFiles();
+            if (files != null) {
+                for (File child : files) {
+                    if (child.isDirectory()) {
+                        collectClassFiles(child.toPath(), result);
+                    } else {
+                        Path relative = child.toPath();
+                        if (isClassFile(relative)) {
+                            result.add(child.getAbsoluteFile());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static void addJDKLibrary(R8Command.Builder builder) throws IOException {
+        String JAVA_HOME = System.getProperty("java.home");
+        if (JAVA_HOME == null) {
+            JAVA_HOME = System.getenv("JAVA_HOME");
+        }
+
+        if (JAVA_HOME == null) {
+            throw new RuntimeException("unable to determine 'java.home' environment variable");
+        }
+
+        builder.addLibraryResourceProvider(JdkClassFileProvider.fromJdkHome(Paths.get(JAVA_HOME)));
+    }
+
+    @Override
+    public void addDependency(File jarOrDir) {
+        if (toMinimize.contains(jarOrDir)) {
+            dependencies.add(jarOrDir);
+        }
+    }
+
+    public static UnusedTracker forProject(Project project, FileCollection apiJars, Iterable<File> sourceSetsClassesDirs, FileCollection toMinimize) {
+        try {
+            Path tmpDir = Paths.get(project.getBuildDir().getAbsolutePath(), TMP_DIR);
+            Files.createDirectories(tmpDir);
+
+            return new UnusedTrackerUsingR8(tmpDir, sourceSetsClassesDirs, apiJars, toMinimize);
+        } catch (IOException ioe) {
+            throw new RuntimeException(ioe);
+        }
+    }
+
+    private static class GradleDiagnosticHandler implements DiagnosticsHandler {
+
+        private static final Logger logger = LoggerFactory.getLogger(GradleVersionUtil.class);
+
+        private final boolean enableInfo;
+
+        GradleDiagnosticHandler(boolean enableInfo) {
+            this.enableInfo = enableInfo;
+        }
+
+        @Override
+        public void error(Diagnostic error) {
+            if (logger.isErrorEnabled()) {
+                DiagnosticsHandler.printDiagnosticToStream(error, "Error", System.err);
+            }
+        }
+
+        @Override
+        public void warning(Diagnostic warning) {
+            if (logger.isWarnEnabled()) {
+                DiagnosticsHandler.printDiagnosticToStream(warning, "Warning", System.out);
+            }
+        }
+
+        @Override
+        public void info(Diagnostic info) {
+            if (logger.isInfoEnabled() && enableInfo) {
+                DiagnosticsHandler.printDiagnosticToStream(info, "Info", System.out);
+            }
+        }
+    }
+}

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.groovy
@@ -39,6 +39,8 @@ import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.commons.ClassRemapper
 
+import java.nio.file.Files
+import java.nio.file.Path
 import java.util.zip.ZipException
 
 @Slf4j
@@ -173,7 +175,11 @@ class ShadowCopyAction implements CopyAction {
         }
 
         protected boolean isClass(FileCopyDetails fileDetails) {
-            return FilenameUtils.getExtension(fileDetails.path) == 'class'
+            return isClass(fileDetails.path)
+        }
+
+        protected boolean isClass(String path) {
+            return FilenameUtils.getExtension(path) == 'class'
         }
 
         @Override
@@ -313,17 +319,38 @@ class ShadowCopyAction implements CopyAction {
             return result
         }
 
+        private InputStream getClassInputStreamFromUnusedTracker(String className) {
+            InputStream is = null
+            if (unusedTracker != null) {
+                Path path = unusedTracker.getPathToProcessedClass(className)
+                if (path != null && Files.exists(path)) {
+                    is = path.newInputStream()
+                }
+            }
+            return is
+        }
+
         private void remapClass(RelativeArchivePath file, ZipFile archive) {
             if (file.classFile) {
                 ZipEntry zipEntry = setArchiveTimes(new ZipEntry(remapper.mapPath(file) + '.class'))
                 addParentDirectories(new RelativeArchivePath(zipEntry))
-                remapClass(archive.getInputStream(file.entry), file.pathString, file.entry.time)
+
+                InputStream is = getClassInputStreamFromUnusedTracker(file.entry.name)
+                if (is == null) {
+                    is = archive.getInputStream(file.entry)
+                }
+
+                remapClass(is, file.pathString, file.entry.time)
             }
         }
 
         private void remapClass(FileCopyDetails fileCopyDetails) {
-            if (FilenameUtils.getExtension(fileCopyDetails.name) == 'class') {
-                InputStream is = fileCopyDetails.file.newInputStream()
+            if (isClass(fileCopyDetails)) {
+                InputStream is = getClassInputStreamFromUnusedTracker(fileCopyDetails.relativePath.pathString)
+                if (is == null) {
+                    is = fileCopyDetails.file.newInputStream()
+                }
+
                 try {
                     remapClass(is, fileCopyDetails.path, fileCopyDetails.lastModified)
                 } finally {
@@ -387,7 +414,16 @@ class ShadowCopyAction implements CopyAction {
             RelativeArchivePath mappedFile = new RelativeArchivePath(entry)
             addParentDirectories(mappedFile)
             zipOutStr.putNextEntry(mappedFile.entry)
-            InputStream is = archive.getInputStream(archiveFile.entry)
+
+            InputStream is =
+                    isClass(archiveFile.entry.name) ?
+                            getClassInputStreamFromUnusedTracker(archiveFile.entry.name) :
+                            null
+
+            if (is == null) {
+                is = archive.getInputStream(archiveFile.entry)
+            }
+
             try {
                 IOUtils.copyLarge(is, zipOutStr)
             } finally {

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowSpec.java
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowSpec.java
@@ -12,6 +12,8 @@ import org.gradle.api.file.CopySpec;
 import java.lang.reflect.InvocationTargetException;
 
 interface ShadowSpec extends CopySpec {
+    ShadowSpec useR8(boolean enabled);
+
     ShadowSpec minimize();
 
     ShadowSpec minimize(Action<DependencyFilter> configureClosure);

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/MinimizeR8Spec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/MinimizeR8Spec.groovy
@@ -1,0 +1,535 @@
+package com.github.jengelman.gradle.plugins.shadow
+
+import com.github.jengelman.gradle.plugins.shadow.util.PluginSpecification
+
+class MinimizeR8Spec extends PluginSpecification {
+
+    /**
+     * 'Server' depends on 'Client'. 'junit' is independent.
+     * The minimize shall remove 'junit'.
+     */
+    def 'minimize by keeping only transitive dependencies'() {
+        given:
+        file('settings.gradle') << """
+            include 'client', 'server'
+        """.stripIndent()
+
+        file('client/src/main/java/client/Client.java') << """
+            package client;
+            public class Client {}
+        """.stripIndent()
+
+        file('client/build.gradle') << """
+            apply plugin: 'java'
+            repositories { maven { url "${repo.uri}" } }
+            dependencies { implementation 'junit:junit:3.8.2' }
+        """.stripIndent()
+
+        file('server/src/main/java/server/Server.java') << """
+            package server;
+
+            import client.Client;
+
+            public class Server {
+                private final String client = Client.class.getName();
+            }
+        """.stripIndent()
+
+        file('server/build.gradle') << """
+            apply plugin: 'java'
+            apply plugin: 'com.github.johnrengelman.shadow'
+
+            shadowJar {
+                useR8(true)
+                minimize()
+            }
+
+            repositories { maven { url "${repo.uri}" } }
+            dependencies { implementation project(':client') }
+        """.stripIndent()
+
+        File serverOutput = getFile('server/build/libs/server-all.jar')
+
+        when:
+        runWithDebug(':server:shadowJar', '--stacktrace')
+
+        then:
+        serverOutput.exists()
+        contains(serverOutput, [
+                'client/Client.class',
+                'server/Server.class'
+        ])
+        doesNotContain(serverOutput, ['junit/framework/Test.class'])
+    }
+
+    /**
+     * 'Client', 'Server' and 'junit' are independent.
+     * 'junit' is excluded from the minimize.
+     * The minimize shall remove 'Client' but not 'junit'.
+     */
+    def 'exclude a dependency from minimize'() {
+        given:
+        file('settings.gradle') << """
+            include 'client', 'server'
+        """.stripIndent()
+
+        file('client/src/main/java/client/Client.java') << """
+            package client;
+            public class Client {}
+        """.stripIndent()
+
+        file('client/build.gradle') << """
+            apply plugin: 'java'
+            repositories { maven { url "${repo.uri}" } }
+            dependencies { implementation 'junit:junit:3.8.2' }
+        """.stripIndent()
+
+        file('server/src/main/java/server/Server.java') << """
+            package server;
+            public class Server {}
+        """.stripIndent()
+
+        file('server/build.gradle') << """
+            apply plugin: 'java'
+            apply plugin: 'com.github.johnrengelman.shadow'
+
+            shadowJar {
+                useR8(true)
+                minimize {
+                    exclude(dependency('junit:junit:.*'))
+                }
+            }
+
+            repositories { maven { url "${repo.uri}" } }
+            dependencies { implementation project(':client') }
+        """.stripIndent()
+
+        File serverOutput = getFile('server/build/libs/server-all.jar')
+
+        when:
+        runWithDebug(':server:shadowJar', '--stacktrace')
+
+        then:
+        serverOutput.exists()
+        contains(serverOutput, [
+                'server/Server.class',
+                'junit/framework/Test.class'
+        ])
+        doesNotContain(serverOutput, ['client/Client.class'])
+    }
+
+    /**
+     * 'Client', 'Server' and 'junit' are independent.
+     * Unused classes of 'client' and theirs dependencies shouldn't be removed.
+     */
+    def 'exclude a project from minimize '() {
+        given:
+        file('settings.gradle') << """
+            include 'client', 'server'
+        """.stripIndent()
+
+        file('client/src/main/java/client/Client.java') << """
+            package client;
+            public class Client {}
+        """.stripIndent()
+
+        file('client/build.gradle') << """
+            apply plugin: 'java'
+            repositories { maven { url "${repo.uri}" } }
+        """.stripIndent()
+
+        file('server/src/main/java/server/Server.java') << """
+            package server;
+            public class Server {}
+        """.stripIndent()
+
+        file('server/build.gradle') << """
+            apply plugin: 'java'
+            apply plugin: 'com.github.johnrengelman.shadow'
+
+            shadowJar {
+                useR8(true)
+                minimize {
+                    exclude(project(':client'))
+                }
+            }
+
+            repositories { maven { url "${repo.uri}" } }
+            dependencies { implementation project(':client') }
+        """.stripIndent()
+
+        File serverOutput = file('server/build/libs/server-all.jar')
+
+        when:
+        runWithDebug(':server:shadowJar', '--stacktrace')
+
+        then:
+        contains(serverOutput, [
+                'client/Client.class',
+                'server/Server.class'
+        ])
+    }
+
+    /**
+     * 'Client', 'Server' and 'junit' are independent.
+     * Unused classes of 'client' and theirs dependencies shouldn't be removed.
+     */
+    def 'exclude a project from minimize - shall not exclude transitive dependencies that are used in subproject'() {
+        given:
+        file('settings.gradle') << """
+            include 'client', 'server'
+        """.stripIndent()
+
+        file('client/src/main/java/client/Client.java') << """
+            package client;
+            import junit.framework.TestCase;
+            public class Client extends TestCase {
+                public static void main(String[] args) {} 
+            }
+        """.stripIndent()
+
+        file('client/build.gradle') << """
+            apply plugin: 'java'
+            repositories { maven { url "${repo.uri}" } }
+            dependencies { implementation 'junit:junit:3.8.2' }
+        """.stripIndent()
+
+        file('server/src/main/java/server/Server.java') << """
+            package server;
+            public class Server {}
+        """.stripIndent()
+
+        file('server/build.gradle') << """
+            apply plugin: 'java'
+            apply plugin: 'com.github.johnrengelman.shadow'
+
+            shadowJar {
+                useR8(true)
+                minimize {
+                    exclude(project(':client'))
+                }
+            }
+
+            repositories { maven { url "${repo.uri}" } }
+            dependencies { implementation project(':client') }
+        """.stripIndent()
+
+        File serverOutput = file('server/build/libs/server-all.jar')
+
+        when:
+        runWithDebug(':server:shadowJar', '--stacktrace')
+
+        then:
+        contains(serverOutput, [
+                'client/Client.class',
+                'server/Server.class',
+                'junit/framework/TestCase.class'
+        ])
+    }
+
+    /**
+     * 'Client', 'Server' and 'junit' are independent.
+     * Unused classes of 'client' and theirs dependencies shouldn't be removed.
+     */
+    def 'exclude a project from minimize - shall not exclude transitive dependencies from subproject that are not used'() {
+        given:
+        file('settings.gradle') << """
+            include 'client', 'server'
+        """.stripIndent()
+
+        file('client/src/main/java/client/Client.java') << """
+            package client;
+            public class Client { }
+        """.stripIndent()
+
+        file('client/build.gradle') << """
+            apply plugin: 'java'
+            repositories { maven { url "${repo.uri}" } }
+            dependencies { implementation 'junit:junit:3.8.2' }
+        """.stripIndent()
+
+        file('server/src/main/java/server/Server.java') << """
+            package server;
+            public class Server {}
+        """.stripIndent()
+
+        file('server/build.gradle') << """
+            apply plugin: 'java'
+            apply plugin: 'com.github.johnrengelman.shadow'
+
+            shadowJar {
+                useR8(true)
+                minimize {
+                    exclude(project(':client'))
+                }
+            }
+
+            repositories { maven { url "${repo.uri}" } }
+            dependencies { implementation project(':client') }
+        """.stripIndent()
+
+        File serverOutput = file('server/build/libs/server-all.jar')
+
+        when:
+        runWithDebug(':server:shadowJar', '--stacktrace')
+
+        then:
+        contains(serverOutput, [
+                'client/Client.class',
+                'server/Server.class',
+                'junit/framework/TestCase.class'
+        ])
+    }
+
+
+    /**
+     * 'api' used as api for 'impl', and depended on 'lib'. 'junit' is independent.
+     * The minimize shall remove 'junit', but not 'api'.
+     * Unused classes of 'api' and their dependencies also shouldn't be removed.
+     * Transitive dependencies (implementation scope) that are not part of the public api
+     * of classes in 'api' are not kept.
+     */
+    def 'use minimize with dependencies with api scope'() {
+        given:
+        file('settings.gradle') << """
+            include 'api', 'lib', 'impl'
+        """.stripIndent()
+
+        file('lib/src/main/java/lib/LibEntity.java') << """
+            package lib;
+            public interface LibEntity {}
+        """.stripIndent()
+
+        file('lib/src/main/java/lib/UnusedLibEntity.java') << """
+            package lib;
+            public class UnusedLibEntity implements LibEntity {}
+        """.stripIndent()
+
+        file('lib/build.gradle') << """
+            apply plugin: 'java'
+            repositories { maven { url "${repo.uri}" } }
+        """.stripIndent()
+
+        file('api/src/main/java/api/Entity.java') << """
+            package api;
+            public interface Entity {}
+        """.stripIndent()
+
+        file('api/src/main/java/api/UnusedEntity.java') << """
+            package api;
+            import lib.LibEntity;
+            public class UnusedEntity implements LibEntity {}
+        """.stripIndent()
+
+        file('api/build.gradle') << """
+            apply plugin: 'java'
+            repositories { maven { url "${repo.uri}" } }
+            dependencies {
+                implementation 'junit:junit:3.8.2'
+                implementation project(':lib')
+            }
+        """.stripIndent()
+
+        file('impl/src/main/java/impl/SimpleEntity.java') << """
+            package impl;
+            import api.Entity;
+            public class SimpleEntity implements Entity {}
+        """.stripIndent()
+
+        file('impl/build.gradle') << """
+            apply plugin: 'java-library'
+            apply plugin: 'com.github.johnrengelman.shadow'
+
+            shadowJar {
+                useR8(true)
+                minimize()
+            }
+
+            repositories { maven { url "${repo.uri}" } }
+            dependencies { api project(':api') }
+        """.stripIndent()
+
+        File serverOutput = getFile('impl/build/libs/impl-all.jar')
+
+        when:
+        runWithDebug(':impl:shadowJar', '--stacktrace')
+
+        then:
+        serverOutput.exists()
+        contains(serverOutput, [
+                'impl/SimpleEntity.class',
+                'api/Entity.class',
+                'api/UnusedEntity.class'
+        ])
+        doesNotContain(serverOutput, ['junit/framework/Test.class', 'lib/UnusedLibEntity.class'])
+    }
+
+    /**
+     * 'api' used as api for 'impl', and depended on 'lib'. 'junit' is independent.
+     * The minimize shall remove 'junit', but not 'api'.
+     * Unused classes of 'api' and their (used) dependencies also shouldn't be removed.
+     * Transitive dependencies (implementation scope) that are part of the public api
+     * of classes in 'api' are kept as well.
+     */
+    def 'use minimize with dependencies with api scope, descriptorclasses kept'() {
+        given:
+        file('settings.gradle') << """
+            include 'api', 'lib', 'impl'
+        """.stripIndent()
+
+        file('lib/src/main/java/lib/LibEntity.java') << """
+            package lib;
+            public interface LibEntity {
+                void simple();
+            }
+        """.stripIndent()
+
+        file('lib/src/main/java/lib/UnusedLibEntity.java') << """
+            package lib;
+            public class UnusedLibEntity implements LibEntity {
+                public void simple() {}
+            }
+        """.stripIndent()
+
+        file('lib/build.gradle') << """
+            apply plugin: 'java'
+            repositories { maven { url "${repo.uri}" } }
+        """.stripIndent()
+
+        file('api/src/main/java/api/Entity.java') << """
+            package api;
+            public interface Entity {}
+        """.stripIndent()
+
+        file('api/src/main/java/api/UnusedEntity.java') << """
+            package api;
+            import lib.LibEntity;
+            public class UnusedEntity implements LibEntity {
+                public void simple() {}
+                public void useLib(LibEntity entity) {
+                    entity.simple();
+                }
+            }
+        """.stripIndent()
+
+        file('api/build.gradle') << """
+            apply plugin: 'java'
+            repositories { maven { url "${repo.uri}" } }
+            dependencies {
+                implementation 'junit:junit:3.8.2'
+                implementation project(':lib')
+            }
+        """.stripIndent()
+
+        file('impl/src/main/java/impl/SimpleEntity.java') << """
+            package impl;
+            import api.Entity;
+            public class SimpleEntity implements Entity {}
+        """.stripIndent()
+
+        file('impl/build.gradle') << """
+            apply plugin: 'java-library'
+            apply plugin: 'com.github.johnrengelman.shadow'
+
+            shadowJar {
+                useR8(true)
+                minimize()
+            }
+
+            repositories { maven { url "${repo.uri}" } }
+            dependencies { api project(':api') }
+        """.stripIndent()
+
+        File serverOutput = getFile('impl/build/libs/impl-all.jar')
+
+        when:
+        runWithDebug(':impl:shadowJar', '--stacktrace')
+
+        then:
+        serverOutput.exists()
+        contains(serverOutput, [
+                'impl/SimpleEntity.class',
+                'api/Entity.class',
+                'api/UnusedEntity.class',
+                'lib/LibEntity.class'
+        ])
+        doesNotContain(serverOutput, ['junit/framework/Test.class', 'lib/UnusedLibEntity.class'])
+    }
+
+    /**
+     * 'api' used as api for 'impl', and 'lib' used as api for 'api'.
+     * Unused classes of 'api' and 'lib' shouldn't be removed.
+     */
+    def 'use minimize with transitive dependencies with api scope'() {
+        given:
+        file('settings.gradle') << """
+            include 'api', 'lib', 'impl'
+        """.stripIndent()
+
+        file('lib/src/main/java/lib/LibEntity.java') << """
+            package lib;
+            public interface LibEntity {}
+        """.stripIndent()
+
+        file('lib/src/main/java/lib/UnusedLibEntity.java') << """
+            package lib;
+            public class UnusedLibEntity implements LibEntity {}
+        """.stripIndent()
+
+        file('lib/build.gradle') << """
+            apply plugin: 'java'
+            repositories { maven { url "${repo.uri}" } }
+        """.stripIndent()
+
+        file('api/src/main/java/api/Entity.java') << """
+            package api;
+            public interface Entity {}
+        """.stripIndent()
+
+        file('api/src/main/java/api/UnusedEntity.java') << """
+            package api;
+            import lib.LibEntity;
+            public class UnusedEntity implements LibEntity {}
+        """.stripIndent()
+
+        file('api/build.gradle') << """
+            apply plugin: 'java-library'
+            repositories { maven { url "${repo.uri}" } }
+            dependencies { api project(':lib') }
+        """.stripIndent()
+
+        file('impl/src/main/java/impl/SimpleEntity.java') << """
+            package impl;
+            import api.Entity;
+            public class SimpleEntity implements Entity {}
+        """.stripIndent()
+
+        file('impl/build.gradle') << """
+            apply plugin: 'java-library'
+            apply plugin: 'com.github.johnrengelman.shadow'
+
+            shadowJar {
+                useR8(true)
+                minimize()
+            }
+
+            repositories { maven { url "${repo.uri}" } }
+            dependencies { api project(':api') }
+        """.stripIndent()
+
+        File serverOutput = getFile('impl/build/libs/impl-all.jar')
+
+        when:
+        runWithDebug(':impl:shadowJar', '--stacktrace')
+
+        then:
+        serverOutput.exists()
+        contains(serverOutput, [
+                'impl/SimpleEntity.class',
+                'api/Entity.class',
+                'api/UnusedEntity.class',
+                'lib/LibEntity.class',
+                'lib/UnusedLibEntity.class'
+        ])
+    }
+}


### PR DESCRIPTION
The PR changes the logic to always retrieve the first child of the dependencies node it it was present.
This fails sometimes ofc if the list of dependencies is empty.
Furthermore, the PR was adding dependencies to the first encountered dependency instead of the dependency list.

This PR fixes it.